### PR TITLE
feat(roc): add Firefly ROC-RK3568-PC host skeleton

### DIFF
--- a/build-iso-image.sh
+++ b/build-iso-image.sh
@@ -1,11 +1,30 @@
 #!/usr/bin/env bash
 # see also: https://nixos.mayflower.consulting/blog/2018/09/11/custom-images/
+#
+# Build a myconfig installer ISO.
+#
+# Usage:
+#   ./build-iso-image.sh [<iso>] [<system>]
+#
+#   <iso>      ISO variant to build (flake package myconfig-<iso>). Default: iso
+#   <system>   Nix system to build for. Default: the current system.
+#              Use "aarch64-linux" to build an AArch64 ISO (e.g. for the
+#              ROC-RK3568-PC and other ARM boots via UEFI).
+#
+# Environment overrides:
+#   SYSTEM     same as the <system> positional argument.
+#
+# Building an aarch64 ISO on an x86_64 host requires either an aarch64 remote
+# builder or local binfmt/qemu emulation:
+#   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
 set -exuo pipefail
 
 writeScripts() {
     local outDir="$1"
     local outFile="$2"
+    local system="$3"
+
     cat <<'EOF' | tee "$outDir/dd.sh"
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash -p parted gptfdisk systemdMinimal e2fsprogs
@@ -22,12 +41,32 @@ sudo dd if="$iso" of="$sdX" bs=4M conv=sync status=progress
 EOF
     chmod +x "$outDir/dd.sh"
 
-    cat <<EOF | tee "$outDir/run-qemu.sh"
+    if [[ $system == aarch64-* ]]; then
+        # Emulated AArch64 UEFI guest: qemu ships the edk2 firmware under
+        # $qemu/share/qemu/edk2-aarch64-code.fd.
+        cat <<EOF | tee "$outDir/run-qemu.sh"
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p qemu
+set -ex
+fw="\$(dirname "\$(command -v qemu-system-aarch64)")/../share/qemu/edk2-aarch64-code.fd"
+qemu-system-aarch64 \\
+    -machine virt \\
+    -cpu cortex-a72 \\
+    -m 4096 \\
+    -smp 4 \\
+    -bios "\$fw" \\
+    -boot d \\
+    -cdrom "$outFile" \\
+    -nographic
+EOF
+    else
+        cat <<EOF | tee "$outDir/run-qemu.sh"
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash -p qemu_kvm
 set -ex
 qemu-kvm -boot d -cdrom "$outFile" -m 32000 -cpu host -smp 6
 EOF
+    fi
     chmod +x "$outDir/run-qemu.sh"
 }
 
@@ -36,29 +75,42 @@ getIsoFromOutLink() {
     local outLink="$2"
     local outArr
     outArr=("$outLink/$iso/"*".iso")
-    echo "$(readlink -f "${outArr[-1]}")"
+    readlink -f "${outArr[-1]}"
 }
 
 build() {
     local iso="$1"
-    local outDir="../$iso"
+    local system="$2"
+
+    # Keep the historical output location for native builds; suffix the
+    # system for cross/emulated builds so the two do not clobber each other.
+    local outDir flakeAttr
+    if [[ $system == "$currentSystem" ]]; then
+        outDir="../$iso"
+        flakeAttr=".#myconfig-$iso"
+    else
+        outDir="../$iso.$system"
+        flakeAttr=".#packages.$system.myconfig-$iso"
+    fi
     local outLink="$outDir/result"
 
-    time nix build --out-link "$outLink" --show-trace .#myconfig-"$iso"
+    time nix build --out-link "$outLink" --show-trace "$flakeAttr"
 
     local out
     out="$(getIsoFromOutLink "$iso" "$outLink")"
     du -h "$out"
 
-    writeScripts "$outDir" "$out"
-    date > "$outDir/date"
-    git log -1 > "$outDir/lastCommit"
+    writeScripts "$outDir" "$out" "$system"
+    date >"$outDir/date"
+    git log -1 >"$outDir/lastCommit"
 }
 
 iso="${1:-iso}"
+currentSystem="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
+system="${2:-${SYSTEM:-$currentSystem}}"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 [[ -d "$HOME/myconfig/priv" ]] && cd "$HOME/myconfig/priv"
 nix flake update
-build "$iso"
+build "$iso" "$system"
 times

--- a/flake.nix
+++ b/flake.nix
@@ -358,6 +358,20 @@
               ]
               ++ moreModules
             ) metadataOverride);
+          host-roc =
+            moreModules: metadataOverride:
+            (self.lib.evalConfiguration "aarch64-linux" "roc" (
+              [
+                self.nixosModules.core
+                (
+                  { pkgs, myconfig, ... }:
+                  {
+                    imports = [ (myconfig.metadatalib.announceOtherHosts "roc") ];
+                  }
+                )
+              ]
+              ++ moreModules
+            ) metadataOverride);
           host-futro =
             moreModules: metadataOverride:
             (self.lib.evalConfiguration "x86_64-linux" "futro" (
@@ -417,6 +431,9 @@
             { myconfig.secretsWarnOnMissingSource = false; }
           ] { };
           test-odroid = self.nixosConfigurationsGen.host-odroid [
+            { myconfig.secretsWarnOnMissingSource = false; }
+          ] { };
+          test-roc = self.nixosConfigurationsGen.host-roc [
             { myconfig.secretsWarnOnMissingSource = false; }
           ] { };
           # test-pi4 = self.nixosConfigurationsGen.host-pi4 [

--- a/hosts/host.roc/README.md
+++ b/hosts/host.roc/README.md
@@ -123,6 +123,13 @@ $ sudo dd \
 Replace `/dev/sdX` with the correct whole-disk device. This operation destroys
 all existing data on that device.
 
+Alternatively use the helper script, which prompts for confirmation and
+unmounts any mounted partitions first:
+
+```console
+$ ./flash-edk2-sd-card.sh ROC-RK3568-PC_EFI.img /dev/sdX
+```
+
 Leave the EDK2 microSD installed during boot.
 
 ## 3. Download and write the NixOS installer
@@ -145,6 +152,12 @@ $ sudo dd \
 ```
 
 Replace `/dev/sdY` with the whole USB-stick device.
+
+Or use the helper script:
+
+```console
+$ ./flash-installer-usb.sh nixos-minimal-<release>-aarch64-linux.iso /dev/sdY
+```
 
 Use the ISO rather than the generic ARM SD image: EDK2 should expose the board
 as a UEFI AArch64 system, allowing the regular NixOS installer to boot
@@ -220,7 +233,17 @@ $ lsblk -o NAME,SIZE,MODEL,SERIAL,TYPE,TRAN,MOUNTPOINTS
 
 ## 7. Partition the target
 
-Create a GPT with a 512 MiB EFI System Partition and an ext4 root partition:
+The `format-target-disk.sh` helper performs the whole partition/format/mount
+sequence below (with a confirmation prompt and automatic `pN`/`N` suffix
+detection), producing the `EFI`/`nixos` filesystem labels expected by
+`hardware-configuration.nix`:
+
+```console
+$ sudo ./format-target-disk.sh /dev/nvme0n1
+```
+
+To do it manually instead, create a GPT with a 512 MiB EFI System Partition
+and an ext4 root partition:
 
 ```console
 $ sudo wipefs -a "$DISK"

--- a/hosts/host.roc/default.nix
+++ b/hosts/host.roc/default.nix
@@ -1,0 +1,76 @@
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+#
+# Firefly ROC-RK3568-PC (aarch64-linux) bootstrap skeleton.
+#
+# See ./README.md for the full installation plan.  This is a minimal,
+# behaviour-light configuration meant to be fleshed out once the hardware
+# has actually booted NixOS.  Anything that depends on real hardware or
+# provisioning data is marked with TODO below.
+{
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ./hardware-configuration.nix
+  ];
+
+  config = {
+    # The ROC-RK3568-PC is brought up through a board-specific EDK2/UEFI
+    # image, so it presents itself as a normal UEFI AArch64 system.
+    boot.loader = {
+      systemd-boot.enable = true;
+      # Embedded UEFI implementations do not always provide reliable
+      # persistent EFI variables; install the removable-media fallback
+      # loader instead.  mkForce overrides the shared systemd-boot module
+      # (modules/boot.loader.systemd-boot.nix) which defaults this to true.
+      efi.canTouchEfiVariables = lib.mkForce false;
+      grub.enable = false;
+    };
+
+    # Prefer a recent kernel while RK3568 mainline support is being
+    # evaluated (see README.md).
+    boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+
+    # TODO: enable and pin the board device tree only after confirming the
+    # DTB exists in the selected kernel package (see README.md):
+    #   hardware.deviceTree = {
+    #     enable = true;
+    #     name = "rockchip/rk3568-firefly-roc-pc.dtb";
+    #   };
+
+    myconfig = {
+      headless.enable = true;
+    };
+
+    networking.hostName = "roc";
+    # TODO: replace with a real, unique 8-hex-digit host id once the machine
+    # is provisioned (e.g. `head -c 8 /etc/machine-id`).
+    networking.hostId = "0c000000";
+
+    # Two Gigabit Ethernet ports; use DHCP until the interface names and
+    # MAC/PHY combinations have been confirmed from the boot log.
+    networking.useDHCP = lib.mkDefault true;
+
+    services.openssh.enable = true;
+
+    # https://github.com/NixOS/nixpkgs/issues/154163
+    # Some Rockchip/aarch64 kernels are missing modules referenced by the
+    # module closure; allow them to be missing so the image still builds.
+    nixpkgs.overlays = [
+      (final: super: {
+        makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+      })
+    ];
+
+    # This value determines the NixOS release from which the default
+    # settings for stateful data, like file locations and database versions
+    # on your system were taken. It‘s perfectly fine and recommended to leave
+    # this value at the release version of the first install of this system.
+    # Before changing this value read the documentation for this option
+    # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+    system.stateVersion = lib.mkForce "25.05"; # Did you read the comment?
+  };
+}

--- a/hosts/host.roc/flash-edk2-sd-card.sh
+++ b/hosts/host.roc/flash-edk2-sd-card.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+#
+# Write the ROC-RK3568-PC EDK2/UEFI firmware image to a microSD card
+# (README.md steps 1-2).
+#
+# Unlike the ODROID-C2 (which boots a single self-built NixOS SD image), the
+# ROC-RK3568-PC is brought up through a board-specific EDK2/UEFI firmware image
+# on microSD.  That microSD stays inserted permanently because it supplies the
+# board firmware on every boot; NixOS itself is installed separately onto NVMe
+# (see flash-installer-usb.sh and format-target-disk.sh).
+#
+# The EDK2 image (`ROC-RK3568-PC_EFI.img`) is NOT built by this flake.  Download
+# a release from:
+#   https://github.com/S199pWa1k9r/edk2-rk356x/releases
+# and pass its path here (or via the EDK2_IMG environment variable).
+#
+# Usage:
+#   ./flash-edk2-sd-card.sh <edk2-image> <device>
+#   EDK2_IMG=ROC-RK3568-PC_EFI.img ./flash-edk2-sd-card.sh /dev/sdX
+#
+# References:
+#   https://github.com/S199pWa1k9r/edk2-rk356x/blob/main/docs/firefly-ROC-RK356x-PC.md
+#   hosts/host.roc/README.md
+
+set -euo pipefail
+
+IMG="${EDK2_IMG:-}"
+DEVICE=""
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [<edk2-image>] <device>
+
+  <edk2-image>   Path to ROC-RK3568-PC_EFI.img (or set EDK2_IMG).
+  <device>       microSD block device to flash (e.g. /dev/sdX, /dev/mmcblk0).
+
+Download the EDK2 firmware image from:
+  https://github.com/S199pWa1k9r/edk2-rk356x/releases
+
+The whole target device is overwritten. Double-check the device name with
+\`lsblk\` before running. Leave this microSD inserted during every boot: it
+provides the board firmware.
+EOF
+    exit 2
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        -h | --help) usage ;;
+        -*) echo "unknown option: $arg" >&2 && usage ;;
+        *)
+            if [[ -z ${IMG} && ! -b ${arg} ]]; then
+                IMG="$arg"
+            else
+                DEVICE="$arg"
+            fi
+            ;;
+    esac
+done
+
+if [[ -z ${IMG} ]]; then
+    echo "error: no EDK2 image given (pass a path or set EDK2_IMG)" >&2
+    usage
+fi
+
+if [[ ! -f ${IMG} ]]; then
+    echo "error: EDK2 image not found: ${IMG}" >&2
+    exit 1
+fi
+
+if [[ -z ${DEVICE} ]]; then
+    echo "error: no target device given" >&2
+    usage
+fi
+
+if [[ ! -b ${DEVICE} ]]; then
+    echo "error: ${DEVICE} is not a block device" >&2
+    exit 1
+fi
+
+echo >&2
+lsblk "${DEVICE}" >&2 || true
+echo "==> EDK2 image: ${IMG} ($(du -h "${IMG}" | cut -f1))" >&2
+echo >&2
+read -r -p "About to OVERWRITE ${DEVICE} with ${IMG##*/}. Type 'yes' to continue: " ans
+if [[ ${ans} != "yes" ]]; then
+    echo "aborted." >&2
+    exit 1
+fi
+
+echo "==> Unmounting any mounted partitions of ${DEVICE} ..." >&2
+for part in "${DEVICE}"?*; do
+    [[ -b ${part} ]] && sudo umount "${part}" 2>/dev/null || true
+done
+
+echo "==> Writing EDK2 firmware to ${DEVICE} ..." >&2
+sudo dd if="${IMG}" of="${DEVICE}" bs=4M conv=fsync status=progress
+
+echo "==> Syncing ..." >&2
+sync
+
+echo "==> Done. Keep this microSD inserted; it supplies the board firmware." >&2

--- a/hosts/host.roc/flash-installer-usb.sh
+++ b/hosts/host.roc/flash-installer-usb.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+#
+# Write the NixOS AArch64 minimal installer ISO to a USB stick
+# (README.md step 3).
+#
+# EDK2 exposes the ROC-RK3568-PC as a UEFI AArch64 system, so the regular
+# upstream NixOS installer ISO boots via EFI/BOOT/BOOTAA64.EFI.  This flake
+# does not build that ISO; download the current minimal aarch64 image from:
+#   https://nixos.org/download/#nixos-iso
+# (file name similar to `nixos-minimal-<release>-aarch64-linux.iso`) and pass
+# its path here (or via the NIXOS_ISO environment variable).
+#
+# Usage:
+#   ./flash-installer-usb.sh <iso> <device>
+#   NIXOS_ISO=nixos-minimal-25.05-aarch64-linux.iso ./flash-installer-usb.sh /dev/sdY
+#
+# References:
+#   https://wiki.nixos.org/wiki/NixOS_on_ARM/UEFI
+#   hosts/host.roc/README.md
+
+set -euo pipefail
+
+ISO="${NIXOS_ISO:-}"
+DEVICE=""
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [<iso>] <device>
+
+  <iso>      Path to a NixOS aarch64 minimal ISO (or set NIXOS_ISO).
+  <device>   USB block device to flash (e.g. /dev/sdY).
+
+Download a current minimal aarch64 ISO from:
+  https://nixos.org/download/#nixos-iso
+
+The whole target device is overwritten. Double-check the device name with
+\`lsblk\` before running.
+EOF
+    exit 2
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        -h | --help) usage ;;
+        -*) echo "unknown option: $arg" >&2 && usage ;;
+        *)
+            if [[ -z ${ISO} && ! -b ${arg} ]]; then
+                ISO="$arg"
+            else
+                DEVICE="$arg"
+            fi
+            ;;
+    esac
+done
+
+if [[ -z ${ISO} ]]; then
+    echo "error: no ISO given (pass a path or set NIXOS_ISO)" >&2
+    usage
+fi
+
+if [[ ! -f ${ISO} ]]; then
+    echo "error: ISO not found: ${ISO}" >&2
+    exit 1
+fi
+
+if [[ -z ${DEVICE} ]]; then
+    echo "error: no target device given" >&2
+    usage
+fi
+
+if [[ ! -b ${DEVICE} ]]; then
+    echo "error: ${DEVICE} is not a block device" >&2
+    exit 1
+fi
+
+echo >&2
+lsblk "${DEVICE}" >&2 || true
+echo "==> ISO: ${ISO} ($(du -h "${ISO}" | cut -f1))" >&2
+echo >&2
+read -r -p "About to OVERWRITE ${DEVICE} with ${ISO##*/}. Type 'yes' to continue: " ans
+if [[ ${ans} != "yes" ]]; then
+    echo "aborted." >&2
+    exit 1
+fi
+
+echo "==> Unmounting any mounted partitions of ${DEVICE} ..." >&2
+for part in "${DEVICE}"?*; do
+    [[ -b ${part} ]] && sudo umount "${part}" 2>/dev/null || true
+done
+
+echo "==> Writing installer ISO to ${DEVICE} ..." >&2
+sudo dd if="${ISO}" of="${DEVICE}" bs=4M conv=fsync status=progress
+
+echo "==> Syncing ..." >&2
+sync
+
+echo "==> Done. Boot the board with the EDK2 microSD + this USB stick inserted." >&2

--- a/hosts/host.roc/format-target-disk.sh
+++ b/hosts/host.roc/format-target-disk.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+#
+# Partition, format and mount the NixOS target disk for the ROC-RK3568-PC
+# (README.md step 7).  Run this FROM the booted NixOS aarch64 installer, as
+# root, before `nixos-generate-config --root /mnt` and `nixos-install`.
+#
+# It creates a GPT with a 512 MiB EFI System Partition (FAT32, label "EFI")
+# and an ext4 root partition (label "nixos"), matching the placeholder
+# by-label devices in hosts/host.roc/hardware-configuration.nix, then mounts
+# them at /mnt and /mnt/boot.
+#
+# NVMe is the preferred target because it leaves the vendor eMMC untouched.
+#
+# Usage:
+#   sudo ./format-target-disk.sh <device>          # e.g. /dev/nvme0n1
+#
+# References:
+#   hosts/host.roc/README.md
+
+set -euo pipefail
+
+DISK=""
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 <device>
+
+  <device>   Whole-disk target for NixOS (e.g. /dev/nvme0n1, /dev/sda).
+
+NVMe is preferred so the vendor eMMC installation stays untouched.
+
+The whole target device is wiped. Verify the device carefully with:
+  lsblk -o NAME,SIZE,MODEL,SERIAL,TYPE,TRAN,MOUNTPOINTS
+EOF
+    exit 2
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        -h | --help) usage ;;
+        -*) echo "unknown option: $arg" >&2 && usage ;;
+        *) DISK="$arg" ;;
+    esac
+done
+
+if [[ -z ${DISK} ]]; then
+    echo "error: no target device given" >&2
+    usage
+fi
+
+if [[ ! -b ${DISK} ]]; then
+    echo "error: ${DISK} is not a block device" >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    echo "error: must run as root (partitioning/formatting/mounting)" >&2
+    exit 1
+fi
+
+# NVMe and eMMC devices use `pN` partition suffixes (e.g. nvme0n1p1); SATA and
+# USB disks such as /dev/sda use plain `N` (e.g. sda1).
+if [[ ${DISK} =~ (nvme[0-9]+n[0-9]+|mmcblk[0-9]+)$ ]]; then
+    ESP="${DISK}p1"
+    ROOT="${DISK}p2"
+else
+    ESP="${DISK}1"
+    ROOT="${DISK}2"
+fi
+
+echo >&2
+lsblk "${DISK}" >&2 || true
+echo >&2
+echo "==> Will create on ${DISK}:" >&2
+echo "      ${ESP}  512 MiB  FAT32  ESP   (label EFI)" >&2
+echo "      ${ROOT} rest     ext4   root  (label nixos)" >&2
+echo >&2
+read -r -p "About to WIPE ${DISK}. Type 'yes' to continue: " ans
+if [[ ${ans} != "yes" ]]; then
+    echo "aborted." >&2
+    exit 1
+fi
+
+echo "==> Wiping existing signatures on ${DISK} ..." >&2
+wipefs -a "${DISK}"
+
+echo "==> Creating GPT partition table ..." >&2
+parted "${DISK}" --script \
+    mklabel gpt \
+    mkpart ESP fat32 1MiB 513MiB \
+    set 1 esp on \
+    mkpart nixos ext4 513MiB 100%
+
+# Give the kernel a moment to pick up the new partition nodes.
+sleep 1
+udevadm settle 2>/dev/null || true
+
+echo "==> Formatting ${ESP} (FAT32, label EFI) ..." >&2
+mkfs.fat -F 32 -n EFI "${ESP}"
+
+echo "==> Formatting ${ROOT} (ext4, label nixos) ..." >&2
+mkfs.ext4 -L nixos "${ROOT}"
+
+echo "==> Mounting root at /mnt and ESP at /mnt/boot ..." >&2
+mount "${ROOT}" /mnt
+mkdir -p /mnt/boot
+mount "${ESP}" /mnt/boot
+
+echo "==> Done. Next:" >&2
+echo "      nixos-generate-config --root /mnt" >&2
+echo "      # review generated hardware-configuration.nix, then install" >&2
+echo "      nixos-install --flake .#roc" >&2

--- a/hosts/host.roc/hardware-configuration.nix
+++ b/hosts/host.roc/hardware-configuration.nix
@@ -1,0 +1,57 @@
+# TODO: This is a PLACEHOLDER hardware configuration for the ROC-RK3568-PC.
+#
+# It must be replaced by the output of `nixos-generate-config --root /mnt`
+# run on the actual board (see ./README.md, section 8).  In particular the
+# following need real, verified values before this host can boot:
+#   - boot.initrd.availableKernelModules (detected storage/USB modules)
+#   - fileSystems."/" and "/boot" device UUIDs
+#   - swapDevices, if any
+#
+# Do NOT invent disk UUIDs here.  The dummy filesystem entries below only
+# exist so the configuration evaluates; they will not produce a bootable
+# system.
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}:
+
+{
+  imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+
+  # TODO: replace with modules detected by nixos-generate-config.
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "usb_storage"
+    "sd_mod"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ ];
+  boot.extraModulePackages = [ ];
+
+  # TODO: replace the placeholder labels/UUIDs below with the real values
+  # from the target disk (see README.md, section 7 formats them as
+  # "EFI" / "nixos").
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/EFI";
+    fsType = "vfat";
+  };
+
+  swapDevices = [ ];
+
+  # Enables DHCP on each ethernet and wireless interface. In case of scripted
+  # networking (the default) this is the recommended approach. When using
+  # systemd-networkd it's still possible to use this option, but it's
+  # recommended to use it in conjunction with explicit per-interface
+  # declarations with `networking.interfaces.<interface>.useDHCP`.
+  networking.useDHCP = lib.mkDefault true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+}

--- a/hosts/metadata.json
+++ b/hosts/metadata.json
@@ -177,6 +177,9 @@
       "network": "home",
       "ip4": "192.168.1.102"
     },
+    "roc": {
+      "network": "home"
+    },
     "odroid": {
       "pubkeys": {
         "/etc/ssh/ssh_host_rsa_key.pub": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCl34VptXQRCm8XR2NHNK2XrwLYYUYAIzCZRYLwfygtnL2mAryOy/baLaDlLDPp5yfhfAgfgqjENWdJJxPTA3EDA3/GQRVV/B0vi5jANcaEnTrVn2HvnAuzjBL2M8U8TbL2IhQIJ/Pmd5jnpTBZ9nJeb/vUlYgvrHQPzlkKUihAJMXviwbd699CPeXlhX9qv17RONPA/T0axumiwrid8Nu0wl1dgo/HeqZ4CWYcLStLrjinOvU8nu7nB40x/tUmA/qTF5jKYbiKXW9JAzhWPpJjOpsap8LIoosv+l/0E8fd9YRyewYVemXvMH7RE9Nt9noAr5JfUrbrkMZXOZydssUBOdlqDlYXOrsEAuCIhxmiIskrpK4JLSo3rlagjEtgWJAXGrBon05WKhGU1WFhNyPXg8lSg0fr54V3EQILVxttn/6oth/K9W2YWts/KtWkwp8YSNqysQPVU6sF9Kz/Lv+XS0U5zjE0sYztT/FlKnDFHFOd1QmvQBti6oLMJJi0Y+9vUi1VZrmCu8CD96YGUfNnQIRNgzdRnwUjW5YsbDe8HFbQ1jyLerN/RMbf+v0zSb+rEb8pT9spDBcvWnNGzc0YrCPx6+0Cju+oZ0z9DrVzrVRgAkTx14LPKGp4QEQU0VTZ5cu+qSc03o459MBswZacapked5kq+S5DQf+hAtPMxQ== mhuber@jail"


### PR DESCRIPTION
Bootstrap an aarch64-linux host for the Firefly ROC-RK3568-PC, wired into the flake via nixosConfigurationsGen.host-roc and a test-roc config.

- default.nix: headless UEFI/systemd-boot config with mkForce canTouchEfiVariables=false (EDK2 embedded UEFI), latest kernel, and the makeModulesClosure allowMissing overlay used by other aarch64 hosts.
- hardware-configuration.nix: clearly-marked PLACEHOLDER stub; real disk UUIDs and detected modules must come from nixos-generate-config.
- metadata.json: minimal roc entry (network only; ip4/pubkeys TODO).

Evaluates cleanly; hardware, hostId, device tree and secrets remain TODO.