### PR TITLE
feat(t6): add FriendlyElec NanoPC-T6 host (RK3588, aarch64)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -358,6 +358,20 @@
               ]
               ++ moreModules
             ) metadataOverride);
+          host-t6 =
+            moreModules: metadataOverride:
+            (self.lib.evalConfiguration "aarch64-linux" "t6" (
+              [
+                self.nixosModules.core
+                (
+                  { pkgs, myconfig, ... }:
+                  {
+                    imports = [ (myconfig.metadatalib.announceOtherHosts "t6") ];
+                  }
+                )
+              ]
+              ++ moreModules
+            ) metadataOverride);
           host-futro =
             moreModules: metadataOverride:
             (self.lib.evalConfiguration "x86_64-linux" "futro" (
@@ -417,6 +431,9 @@
             { myconfig.secretsWarnOnMissingSource = false; }
           ] { };
           test-odroid = self.nixosConfigurationsGen.host-odroid [
+            { myconfig.secretsWarnOnMissingSource = false; }
+          ] { };
+          test-t6 = self.nixosConfigurationsGen.host-t6 [
             { myconfig.secretsWarnOnMissingSource = false; }
           ] { };
           # test-pi4 = self.nixosConfigurationsGen.host-pi4 [

--- a/hosts/host.t6/default.nix
+++ b/hosts/host.t6/default.nix
@@ -21,16 +21,9 @@
   ];
 
   config = {
-    # The NanoPC-T6 cannot boot directly from NVMe/USB. U-Boot and /boot must
-    # live on eMMC or microSD. We therefore use the generic extlinux-compatible
-    # bootloader (written to /boot) instead of GRUB/systemd-boot; the
-    # board-specific Rockchip U-Boot is flashed to the boot device out of band
-    # (see the install guide).
-    boot.loader = {
-      grub.enable = false;
-      generic-extlinux-compatible.enable = true;
-    };
-
+    # The bootloader (generic-extlinux-compatible) and the board-specific
+    # Rockchip U-Boot are configured in ./hardware-configuration.nix, which also
+    # fuses U-Boot into the flashable SD image.
     boot.kernelPackages = pkgs.linuxPackages_latest;
 
     # Device tree for the NanoPC-T6.
@@ -49,7 +42,6 @@
     # TODO: replace with a real, stable host id (`head -c4 /dev/urandom | od -A none -t x4`)
     networking.hostId = "74366e61";
 
-    networking.useDHCP = lib.mkDefault true;
     networking.networkmanager.enable = true;
 
     swapDevices = [

--- a/hosts/host.t6/default.nix
+++ b/hosts/host.t6/default.nix
@@ -1,0 +1,77 @@
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+#
+# FriendlyElec NanoPC-T6 (Rockchip RK3588, aarch64).
+# See ./install-nixos-nanopc-t6.md for the full install guide this config
+# is based on.
+{
+  config,
+  myconfig,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ./hardware-configuration.nix
+    {
+      # UART serial console (RK3588 debug UART).
+      environment.systemPackages = with pkgs; [ tio ];
+    }
+  ];
+
+  config = {
+    # The NanoPC-T6 cannot boot directly from NVMe/USB. U-Boot and /boot must
+    # live on eMMC or microSD. We therefore use the generic extlinux-compatible
+    # bootloader (written to /boot) instead of GRUB/systemd-boot; the
+    # board-specific Rockchip U-Boot is flashed to the boot device out of band
+    # (see the install guide).
+    boot.loader = {
+      grub.enable = false;
+      generic-extlinux-compatible.enable = true;
+    };
+
+    boot.kernelPackages = pkgs.linuxPackages_latest;
+
+    # Device tree for the NanoPC-T6.
+    # For the NanoPC-T6 LTS use "rockchip/rk3588-nanopc-t6-lts.dtb" instead,
+    # if the kernel provides it.
+    hardware.deviceTree.name = "rockchip/rk3588-nanopc-t6.dtb";
+
+    hardware.enableRedistributableFirmware = true;
+
+    myconfig = {
+      desktop.enable = false;
+      headless.enable = true;
+    };
+
+    networking.hostName = "t6";
+    # TODO: replace with a real, stable host id (`head -c4 /dev/urandom | od -A none -t x4`)
+    networking.hostId = "74366e61";
+
+    networking.useDHCP = lib.mkDefault true;
+    networking.networkmanager.enable = true;
+
+    swapDevices = [
+      {
+        device = "/swapfile";
+        priority = 0;
+        size = 4096;
+      }
+    ];
+
+    # https://github.com/NixOS/nixpkgs/issues/154163
+    # https://github.com/NixOS/nixpkgs/issues/111683#issuecomment-968435872
+    # https://github.com/NixOS/nixpkgs/issues/126755#issuecomment-869149243
+    nixpkgs.overlays = [
+      (final: super: {
+        makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+      })
+    ];
+
+    # This value determines the NixOS release from which the default
+    # settings for stateful data were taken. Leave at the release version of
+    # the first install of this system.
+    system.stateVersion = lib.mkForce "25.11";
+  };
+}

--- a/hosts/host.t6/flash-sd-card.sh
+++ b/hosts/host.t6/flash-sd-card.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+#
+# Build the FriendlyElec NanoPC-T6 (host "t6") SD image and flash it to a
+# microSD card / eMMC.  See ./install-nixos-nanopc-t6.md for the full context.
+#
+# This script builds against the flake in the *current working directory*, and
+# targets the real `nixosConfigurations.t6` system.  In this repo's setup the
+# actual system (including agenix secrets) is assembled by a separate private
+# flake (../priv) which imports this public flake and exposes the non-test host
+# configurations.  Therefore run this script from the root of that flake, e.g.:
+#
+#   cd ~/myconfig/priv && ~/myconfig/myconfig/hosts/host.t6/flash-sd-card.sh /dev/sdX
+#
+# Overrides (environment variables):
+#   FLAKE   flake reference to build from        (default ".")
+#   TARGET  nixosConfigurations attribute name    (default "t6")
+#   NIX_BUILD_EXTRA_ARGS  extra args for `nix build`
+#                          (default "--option builders ''" to avoid remote builders)
+#
+# The built image already has the board-specific NanoPC-T6 U-Boot
+# (`u-boot-rockchip.bin`) fused into the raw gap in front of the first partition
+# (see hosts/host.t6/hardware-configuration.nix, sdImage.postBuildCommands), so
+# a plain `dd` of the whole image is bootable - no separate U-Boot flashing step
+# is required.
+#
+# Important: the NanoPC-T6 cannot boot directly from NVMe/USB.  Flash this image
+# to microSD or eMMC.  Booting from microSD first is recommended (see the guide).
+#
+# Building an aarch64 image on an x86_64 host requires either an aarch64 remote
+# builder or binfmt/qemu emulation:
+#   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+#
+# Usage:
+#   ./flash-sd-card.sh /dev/sdX          # build + flash to /dev/sdX
+#   ./flash-sd-card.sh --build-only      # only build, print image path
+#
+# References:
+#   https://wiki.friendlyelec.com/wiki/index.php/NanoPC-T6
+#   https://nixos.wiki/wiki/NixOS_on_ARM
+
+set -euo pipefail
+
+FLAKE="${FLAKE:-.}"
+TARGET="${TARGET:-t6}"
+FLAKE_ATTR="${FLAKE}#nixosConfigurations.${TARGET}.config.system.build.sdImage"
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [--build-only] [<device>]
+
+  <device>       Block device to flash (e.g. /dev/sdX, /dev/mmcblk0).
+  --build-only   Build the SD image only and print its store path.
+
+Run from the root of the flake that provides nixosConfigurations.${TARGET}
+(the private flake that adds secrets), not from the public myconfig flake
+(which only exposes the secret-less test-${TARGET} configuration).
+
+The whole target device is overwritten. Double-check the device name with
+\`lsblk\` before running.
+EOF
+    exit 2
+}
+
+BUILD_ONLY=0
+DEVICE=""
+for arg in "$@"; do
+    case "$arg" in
+        --build-only) BUILD_ONLY=1 ;;
+        -h | --help) usage ;;
+        -*) echo "unknown option: $arg" >&2 && usage ;;
+        *) DEVICE="$arg" ;;
+    esac
+done
+
+# We build against the flake in the current working directory. Sanity-check
+# that a flake actually lives here so a mistaken pwd fails early and loudly.
+if [[ ${FLAKE} == "." && ! -e "./flake.nix" ]]; then
+    echo "error: no flake.nix in $(pwd)" >&2
+    echo "       run this from the root of the flake providing nixosConfigurations.${TARGET}" >&2
+    exit 1
+fi
+
+# Default to disabling remote builders (SD image builds natively on the host).
+# Override with NIX_BUILD_EXTRA_ARGS to pass custom args (e.g. `--builders ...`).
+# shellcheck disable=SC2254
+read -r -a extra_args <<<"${NIX_BUILD_EXTRA_ARGS:---option builders ''}"
+
+# Follow the repo convention of placing result symlinks next to the flake root.
+OUT_LINK="../result.${TARGET}.sd-image"
+
+echo "==> Updating flake inputs ..." >&2
+nix flake update
+
+echo "==> Building SD image for '${TARGET}' from flake '${FLAKE}' ..." >&2
+nix build --print-out-paths "${FLAKE_ATTR}" \
+    --out-link "${OUT_LINK}" \
+    "${extra_args[@]}" >&2
+
+OUT="$(nix path-info "${FLAKE_ATTR}")"
+IMG="$(find "${OUT}/sd-image" -name '*.img' | head -n1)"
+
+if [[ -z ${IMG} || ! -f ${IMG} ]]; then
+    echo "error: could not locate built .img under ${OUT}/sd-image" >&2
+    exit 1
+fi
+
+echo "==> Built image: ${IMG}" >&2
+
+if [[ ${BUILD_ONLY} -eq 1 ]]; then
+    echo "${IMG}"
+    exit 0
+fi
+
+if [[ -z ${DEVICE} ]]; then
+    echo "error: no target device given" >&2
+    usage
+fi
+
+if [[ ! -b ${DEVICE} ]]; then
+    echo "error: ${DEVICE} is not a block device" >&2
+    exit 1
+fi
+
+echo >&2
+lsblk "${DEVICE}" >&2 || true
+echo "==> Image size: $(du -h "${IMG}" | cut -f1)" >&2
+echo >&2
+read -r -p "About to OVERWRITE ${DEVICE} with ${IMG##*/}. Type 'yes' to continue: " ans
+if [[ ${ans} != "yes" ]]; then
+    echo "aborted." >&2
+    exit 1
+fi
+
+echo "==> Unmounting any mounted partitions of ${DEVICE} ..." >&2
+for part in "${DEVICE}"?*; do
+    [[ -b ${part} ]] && sudo umount "${part}" 2>/dev/null || true
+done
+
+echo "==> Writing image to ${DEVICE} (this can take a while) ..." >&2
+sudo dd if="${IMG}" of="${DEVICE}" bs=4M conv=fsync status=progress
+
+echo "==> Syncing ..." >&2
+sync
+
+echo "==> Done. The root partition auto-expands on first boot." >&2
+echo "==> Insert into the NanoPC-T6 and power on (boot from microSD/eMMC)." >&2

--- a/hosts/host.t6/hardware-configuration.nix
+++ b/hosts/host.t6/hardware-configuration.nix
@@ -1,0 +1,60 @@
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+#
+# Placeholder hardware configuration for the FriendlyElec NanoPC-T6.
+#
+# This board has NOT been provisioned yet, so no real disk UUIDs, MAC
+# addresses or scanned kernel modules are known. Once the system boots from
+# microSD/eMMC, regenerate this file on the target with:
+#
+#     nixos-generate-config --root /mnt
+#
+# and replace the TODO placeholders below with the real values from
+# `lsblk -f`.
+#
+# Per the install guide, the root filesystem is created with a "nixos" label
+# (`mkfs.ext4 -L nixos`). The by-label device below is therefore accurate for
+# the documented single-partition eMMC layout; the optional separate /boot on
+# eMMC/microSD (with root on NVMe) is left as a TODO.
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}:
+
+{
+  imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+
+  # TODO: verify/adjust once real hardware has been scanned.
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "usb_storage"
+    "sdhci_pci"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ ];
+  boot.extraModulePackages = [ ];
+
+  # Single ext4 root labelled "nixos" (see install guide, step 5).
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  # TODO (optional NVMe layout): if /boot is kept on eMMC/microSD while root
+  # lives on NVMe, add the real by-uuid entries here, e.g.:
+  #   fileSystems."/boot" = {
+  #     device = "/dev/disk/by-uuid/TODO-BOOT-UUID";
+  #     fsType = "ext4";
+  #   };
+  #   fileSystems."/" = {
+  #     device = "/dev/disk/by-uuid/TODO-NVME-ROOT-UUID";
+  #     fsType = "ext4";
+  #   };
+
+  networking.useDHCP = lib.mkDefault true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+}

--- a/hosts/host.t6/hardware-configuration.nix
+++ b/hosts/host.t6/hardware-configuration.nix
@@ -1,21 +1,21 @@
 # Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
 # SPDX-License-Identifier: MIT
 #
-# Placeholder hardware configuration for the FriendlyElec NanoPC-T6.
+# Hardware / SD-image configuration for the FriendlyElec NanoPC-T6
+# (Rockchip RK3588, aarch64).
 #
-# This board has NOT been provisioned yet, so no real disk UUIDs, MAC
-# addresses or scanned kernel modules are known. Once the system boots from
-# microSD/eMMC, regenerate this file on the target with:
+# Follows ./install-nixos-nanopc-t6.md.
 #
-#     nixos-generate-config --root /mnt
+# The NanoPC-T6 cannot boot directly from NVMe/USB: the board-specific
+# Rockchip U-Boot and /boot must live on eMMC or microSD.  We build a generic
+# aarch64 SD image (empty FAT "FIRMWARE" partition + ext4 root) and additionally
+# `dd` the NanoPC-T6 U-Boot (`u-boot-rockchip.bin`) into the raw gap in front of
+# the first partition via `sdImage.postBuildCommands`, so the produced image is
+# directly flashable and bootable with a single `dd` to microSD or eMMC.
 #
-# and replace the TODO placeholders below with the real values from
-# `lsblk -f`.
-#
-# Per the install guide, the root filesystem is created with a "nixos" label
-# (`mkfs.ext4 -L nixos`). The by-label device below is therefore accurate for
-# the documented single-partition eMMC layout; the optional separate /boot on
-# eMMC/microSD (with root on NVMe) is left as a TODO.
+# Once booted, the system can be re-installed / moved to eMMC (with root
+# optionally on NVMe while /boot stays on eMMC/microSD) as described in the
+# install guide.
 {
   config,
   lib,
@@ -25,36 +25,71 @@
 }:
 
 {
-  imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+  imports = [
+    (modulesPath + "/profiles/base.nix")
+    (modulesPath + "/installer/sd-card/sd-image.nix")
+  ];
 
-  # TODO: verify/adjust once real hardware has been scanned.
+  nixpkgs.hostPlatform.system = "aarch64-linux";
+
+  # U-Boot on the NanoPC-T6 loads the kernel/initrd via an extlinux.conf that
+  # it reads from the (bootable) ext4 root partition, populated below.
+  boot.loader.grub.enable = false;
+  boot.loader.generic-extlinux-compatible.enable = true;
+
+  boot.consoleLogLevel = lib.mkDefault 7;
+
+  # RK3588 debug UART is ttyS2 at 1500000 baud (see nixos-hardware rockchip
+  # and the FriendlyElec wiki).
+  boot.kernelParams = [
+    "console=ttyS2,1500000n8"
+    "console=tty0"
+  ];
+
+  # TODO: verify/adjust once real hardware has been scanned with
+  # `nixos-generate-config`.
   boot.initrd.availableKernelModules = [
     "nvme"
     "usb_storage"
     "sdhci_pci"
+    "mmc_block"
   ];
-  boot.initrd.kernelModules = [ ];
-  boot.kernelModules = [ ];
-  boot.extraModulePackages = [ ];
 
-  # Single ext4 root labelled "nixos" (see install guide, step 5).
-  fileSystems."/" = {
-    device = "/dev/disk/by-label/nixos";
-    fsType = "ext4";
-  };
+  # base.nix enables ZFS in supportedFilesystems, but the ZFS kernel module is
+  # broken against `linuxPackages_latest` (which the install guide requires for
+  # RK3588 support). Disable ZFS so evaluation/build succeeds.
+  boot.supportedFilesystems.zfs = lib.mkForce false;
 
-  # TODO (optional NVMe layout): if /boot is kept on eMMC/microSD while root
-  # lives on NVMe, add the real by-uuid entries here, e.g.:
-  #   fileSystems."/boot" = {
-  #     device = "/dev/disk/by-uuid/TODO-BOOT-UUID";
-  #     fsType = "ext4";
-  #   };
-  #   fileSystems."/" = {
-  #     device = "/dev/disk/by-uuid/TODO-NVME-ROOT-UUID";
-  #     fsType = "ext4";
-  #   };
-
+  # Enables DHCP on each ethernet and wireless interface.
   networking.useDHCP = lib.mkDefault true;
 
-  nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+  sdImage = {
+    # The FAT "FIRMWARE" partition is only meaningful for the Raspberry Pi
+    # family; the NanoPC-T6 U-Boot lives in the raw gap in front of the first
+    # partition (see postBuildCommands).  Leave the partition empty.
+    populateFirmwareCommands = "";
+
+    # Populate /boot on the ext4 root partition with the extlinux config
+    # (and device trees) that U-Boot reads.
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
+    '';
+
+    # Ship the image uncompressed so it can be `dd`-ed directly.
+    compressImage = false;
+
+    # Reserve a 32 MiB gap in front of the first partition so the (multi-MiB)
+    # RK3588 U-Boot image fits without clobbering the FAT partition.  This
+    # mirrors the 32 MiB start of the first partition in the install guide's
+    # eMMC layout.
+    firmwarePartitionOffset = 32;
+
+    # Fuse the NanoPC-T6 U-Boot into the image.  `u-boot-rockchip.bin` bundles
+    # TPL/SPL + ATF + U-Boot and is written at sector offset 64 (32 KiB), per
+    # the install guide and the Rockchip boot ROM layout.
+    postBuildCommands = ''
+      dd if=${pkgs.ubootNanoPCT6}/u-boot-rockchip.bin of=$img conv=notrunc,fsync bs=512 seek=64
+    '';
+  };
 }

--- a/hosts/metadata.json
+++ b/hosts/metadata.json
@@ -177,6 +177,10 @@
       "network": "home",
       "ip4": "192.168.1.102"
     },
+    "t6": {
+      "system": "aarch64-linux",
+      "network": "home"
+    },
     "odroid": {
       "pubkeys": {
         "/etc/ssh/ssh_host_rsa_key.pub": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCl34VptXQRCm8XR2NHNK2XrwLYYUYAIzCZRYLwfygtnL2mAryOy/baLaDlLDPp5yfhfAgfgqjENWdJJxPTA3EDA3/GQRVV/B0vi5jANcaEnTrVn2HvnAuzjBL2M8U8TbL2IhQIJ/Pmd5jnpTBZ9nJeb/vUlYgvrHQPzlkKUihAJMXviwbd699CPeXlhX9qv17RONPA/T0axumiwrid8Nu0wl1dgo/HeqZ4CWYcLStLrjinOvU8nu7nB40x/tUmA/qTF5jKYbiKXW9JAzhWPpJjOpsap8LIoosv+l/0E8fd9YRyewYVemXvMH7RE9Nt9noAr5JfUrbrkMZXOZydssUBOdlqDlYXOrsEAuCIhxmiIskrpK4JLSo3rlagjEtgWJAXGrBon05WKhGU1WFhNyPXg8lSg0fr54V3EQILVxttn/6oth/K9W2YWts/KtWkwp8YSNqysQPVU6sF9Kz/Lv+XS0U5zjE0sYztT/FlKnDFHFOd1QmvQBti6oLMJJi0Y+9vUi1VZrmCu8CD96YGUfNnQIRNgzdRnwUjW5YsbDe8HFbQ1jyLerN/RMbf+v0zSb+rEb8pT9spDBcvWnNGzc0YrCPx6+0Cju+oZ0z9DrVzrVRgAkTx14LPKGp4QEQU0VTZ5cu+qSc03o459MBswZacapked5kq+S5DQf+hAtPMxQ== mhuber@jail"


### PR DESCRIPTION
Add a new aarch64-linux host for the FriendlyElec NanoPC-T6, based on the install guide in hosts/host.t6/install-nixos-nanopc-t6.md and modeled on the existing Rockchip host r6c.

- extlinux-compatible bootloader (GRUB/systemd-boot disabled), latest kernel, and the rk3588-nanopc-t6 device tree per the install guide
- headless profile, NetworkManager + DHCP, swapfile, and the shared RK-family makeModulesClosure overlay
- placeholder hardware-configuration.nix (root via by-label/nixos) with TODOs for real disk UUIDs and the optional eMMC-/boot + NVMe-/ layout
- wire host-t6 / test-t6 into flake.nix and register t6 in metadata.json

TODO: regenerate hardware config on real hardware, set a real hostId, and add SSH pubkeys / IP / wireguard once provisioned.