### PR TITLE
feat(observability.host.litellm): provision upstream Grafana dashboard via nvfetcher

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "grafana-skills": {
         "cargoLock": null,
-        "date": "2026-07-31",
+        "date": "2026-08-05",
         "extract": null,
         "name": "grafana-skills",
         "passthru": null,
@@ -13,11 +13,26 @@
             "name": null,
             "owner": "grafana",
             "repo": "skills",
-            "rev": "80bb2938892c71f27360c936e68a27fa018e086f",
-            "sha256": "sha256-dDmINDx9AmIUyDkNp8+dzjItErqAWkiq8zF03zgoZg0=",
+            "rev": "d9dfb9ec7a6b1ac6c8ec9741ec045ad6f412dec6",
+            "sha256": "sha256-blw2Xpo1IzS5EfYC4TBRQj6ozRJPWe+8vGtz+GaDpts=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "80bb2938892c71f27360c936e68a27fa018e086f"
+        "version": "d9dfb9ec7a6b1ac6c8ec9741ec045ad6f412dec6"
+    },
+    "litellm-grafana-dashboard": {
+        "cargoLock": null,
+        "date": "2026-08-04",
+        "extract": null,
+        "name": "litellm-grafana-dashboard",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": "litellm-grafana-dashboard.json",
+            "sha256": "sha256-EteGQo3xd5GvvkjKre7wqOZ6Hr/Yty78VZe6le55Zcw=",
+            "type": "url",
+            "url": "https://raw.githubusercontent.com/BerriAI/litellm/ead62528e607b9d8e61273def638799c9c3a69ba/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json"
+        },
+        "version": "ead62528e607b9d8e61273def638799c9c3a69ba"
     }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -8,14 +8,24 @@
 {
   grafana-skills = {
     pname = "grafana-skills";
-    version = "80bb2938892c71f27360c936e68a27fa018e086f";
+    version = "d9dfb9ec7a6b1ac6c8ec9741ec045ad6f412dec6";
     src = fetchFromGitHub {
       owner = "grafana";
       repo = "skills";
-      rev = "80bb2938892c71f27360c936e68a27fa018e086f";
+      rev = "d9dfb9ec7a6b1ac6c8ec9741ec045ad6f412dec6";
       fetchSubmodules = false;
-      sha256 = "sha256-dDmINDx9AmIUyDkNp8+dzjItErqAWkiq8zF03zgoZg0=";
+      sha256 = "sha256-blw2Xpo1IzS5EfYC4TBRQj6ozRJPWe+8vGtz+GaDpts=";
     };
-    date = "2026-07-31";
+    date = "2026-08-05";
+  };
+  litellm-grafana-dashboard = {
+    pname = "litellm-grafana-dashboard";
+    version = "ead62528e607b9d8e61273def638799c9c3a69ba";
+    src = fetchurl {
+      url = "https://raw.githubusercontent.com/BerriAI/litellm/ead62528e607b9d8e61273def638799c9c3a69ba/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json";
+      name = "litellm-grafana-dashboard.json";
+      sha256 = "sha256-EteGQo3xd5GvvkjKre7wqOZ6Hr/Yty78VZe6le55Zcw=";
+    };
+    date = "2026-08-04";
   };
 }

--- a/modules/myconfig.observability/dashboards/README.md
+++ b/modules/myconfig.observability/dashboards/README.md
@@ -64,32 +64,89 @@ Each dashboard is passed through `jq` at NixOS build time to:
 
 Unlike the UniFi JSON files above, the LiteLLM Grafana dashboard is
 **not** committed to this directory. It is fetched at build time from
-the upstream LiteLLM repository and rewritten on the fly:
+the upstream LiteLLM repository and rewritten on the fly. Two helper
+files *are* committed here and contain only repository-specific
+additions — never a copy of the upstream dashboard:
 
-- **Pin**: `nvfetcher.toml` entry `litellm-grafana-dashboard` tracks
-  LiteLLM's `main` branch (`src.git`), but `fetch.url` downloads only
-  the dashboard JSON from the exact commit nvfetcher resolves
-  (`$ver` → immutable commit). The commit and hash are frozen in
-  `_sources/generated.nix` (regenerate with `nix run nixpkgs#nvfetcher`).
-  No upstream repository clone enters the Nix store.
-- **Upstream path** (inside `BerriAI/litellm`):
-  `cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json`.
-- **Build-time rewrite** (see `../host.litellm.nix`, `dashboardRewriteJq`):
-  strips `__inputs`/`__requires`, clears the numeric Grafana `id`, pins
-  a stable `uid = "myconfig-litellm"`, localises title/tags, drops the
-  `DS_PROMETHEUS` datasource template variable, removes panels that
-  depend on LiteLLM virtual keys / teams / database-backed accounting
-  (this deployment runs no database — see the module header), and
-  rewrites every Prometheus datasource reference to
-  `{ type: "prometheus", uid: "victoriametrics" }` (the Grafana
-  built-in `"-- Grafana --"` annotation and `null` datasources are
-  preserved). The rewrite uses the recursive `(.. | objects | select(has("datasource")))`
-  `jq` update pattern — the same approach as the UniFi transform, no
-  `walk` dependency.
-- **Result**: a single `litellm.json` placed in a `runCommand` output
-  dir consumed by the Grafana file provider (folder `AI`).
+- `litellm-rewrite.jq` — the build-time `jq` rewrite program.
+- `litellm-local.json` — a small fragment with the `$host` / `$model`
+  template variables and the locally maintained operational panels.
+
+### Pin
+
+`nvfetcher.toml` entry `litellm-grafana-dashboard` tracks LiteLLM's
+`main` branch (`src.git`), but `fetch.url` downloads only the dashboard
+JSON from the exact commit nvfetcher resolves (`$ver` -> immutable
+commit). The commit and hash are frozen in `_sources/generated.nix`
+(regenerate with `nix run nixpkgs#nvfetcher`); the generated URL
+contains a full 40-char Git commit, so the fetch is immutable. No
+upstream repository clone enters the Nix store — only the single JSON
+file, consumed via `pkgs.fetchurl` (not `fetchFromGitHub`).
+
+Upstream path (inside `BerriAI/litellm`):
+`cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json`.
+
+### Build-time rewrite (`litellm-rewrite.jq`, wired by `../host.litellm.nix`)
+
+The upstream JSON is piped through `litellm-rewrite.jq` inside a
+`runCommand`, with `litellm-local.json` slurped via `--slurpfile local`.
+The rewrite:
+
+1. Strips `__inputs` / `__requires`, clears the numeric Grafana `id`,
+   pins a stable `uid = "myconfig-litellm"` (so rebuilds update the same
+   dashboard row instead of cloning), and localises `title` / `tags`.
+2. Drops the upstream `DS_PROMETHEUS` datasource template variable.
+3. Removes panels that depend on LiteLLM virtual keys / teams /
+   database-backed spend (grouped by `api_key_alias` / `team_alias`, or
+   referencing `litellm_spend_metric_total`). This deployment runs no
+   LiteLLM database, so those panels would always be empty. Removal
+   matches on a stable-title substring **and** PromQL-label usage, not
+   panel position.
+4. Rewrites only *known Prometheus* datasource references (string or
+   object form — `${DS_PROMETHEUS}`, `$DS_PROMETHEUS`, `prometheus`, or
+   `{ type: "prometheus", uid: "..." }`) to
+   `{ type: "prometheus", uid: "victoriametrics" }`. The Grafana
+   built-in `"-- Grafana --"` annotation datasource (string or object)
+   and `null` datasources are preserved, as are any unrelated
+   datasource types — the rewrite will not silently turn a future
+   Loki/Tempo datasource into Prometheus.
+5. Rewrites upstream PromQL: fixes two legacy gauge names the pinned
+   upstream still references, inserts `host=~"$host"` into every
+   `litellm_*` metric (all scraped series carry the `host` external
+   label from vmagent), and switches the fixed `[2m]` window to
+   `$__rate_interval`. Model filtering is **not** blanket-applied (not
+   every metric exposes the `requested_model` label); the local panels
+   add it where the metric supports it.
+6. Appends the local additions from `litellm-local.json`: the `$host`
+   and `$model` template variables plus the locally maintained panels
+   (request-by-model, failure-rate ratio, latency p50/p95, TTFT,
+   overhead, token throughput, deployment health, fallbacks). Local
+   panels are offset below the last upstream panel so nothing overlaps
+   regardless of upstream drift.
+7. Asserts the final structure (panels array, title, `$host` / `$model`
+   variables, a `victoriametrics` datasource reference, at least one
+   LiteLLM PromQL target, and at least one request / failure / latency
+   panel) so an upstream change that breaks the assumptions fails the
+   build loudly. A trailing `jq -e .` fails it on invalid JSON.
+
+### Scrape & datasource
+
+- vmagent scrapes the **trailing-slash** endpoint `/metrics/` (the bare
+  `/metrics` endpoint redirects with HTTP 307). See
+  `modules/myconfig.observability/client.nix` (job `litellm`).
+- The dashboard uses the datasource UID `victoriametrics` (the existing
+  VictoriaMetrics Grafana datasource). No PostgreSQL, Prisma, virtual-key,
+  team, or spend-log configuration is involved — the operational metrics
+  come from LiteLLM's `prometheus` callback and need no database. Spend
+  logs remain disabled.
+
+### Result
+
+A single `litellm.json` placed in a `runCommand` output dir consumed by
+the Grafana file provider (folder `AI`, UID `myconfig-litellm`).
 
 To refresh the upstream dashboard, run `nix run nixpkgs#nvfetcher`
-(which updates only the LiteLLM entry's pinned commit/hash — note it
-also re-checks every other nvfetcher source) and review the resulting
-`_sources/generated.nix` diff.
+(which re-checks every nvfetcher source, not only LiteLLM) and review
+the resulting `_sources/generated.nix` diff. If the rewrite assertions
+then fail, `litellm-rewrite.jq` / `litellm-local.json` need updating to
+match the new upstream layout.

--- a/modules/myconfig.observability/dashboards/README.md
+++ b/modules/myconfig.observability/dashboards/README.md
@@ -57,3 +57,39 @@ Each dashboard is passed through `jq` at NixOS build time to:
 3. Replace the top-level `uid` with a stable `myconfig-unifi-<slug>`
    so subsequent rebuilds update the same dashboard row in Grafana
    instead of cloning a new one.
+
+---
+
+## LiteLLM dashboard (fetched via nvfetcher, NOT vendored here)
+
+Unlike the UniFi JSON files above, the LiteLLM Grafana dashboard is
+**not** committed to this directory. It is fetched at build time from
+the upstream LiteLLM repository and rewritten on the fly:
+
+- **Pin**: `nvfetcher.toml` entry `litellm-grafana-dashboard` tracks
+  LiteLLM's `main` branch (`src.git`), but `fetch.url` downloads only
+  the dashboard JSON from the exact commit nvfetcher resolves
+  (`$ver` → immutable commit). The commit and hash are frozen in
+  `_sources/generated.nix` (regenerate with `nix run nixpkgs#nvfetcher`).
+  No upstream repository clone enters the Nix store.
+- **Upstream path** (inside `BerriAI/litellm`):
+  `cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json`.
+- **Build-time rewrite** (see `../host.litellm.nix`, `dashboardRewriteJq`):
+  strips `__inputs`/`__requires`, clears the numeric Grafana `id`, pins
+  a stable `uid = "myconfig-litellm"`, localises title/tags, drops the
+  `DS_PROMETHEUS` datasource template variable, removes panels that
+  depend on LiteLLM virtual keys / teams / database-backed accounting
+  (this deployment runs no database — see the module header), and
+  rewrites every Prometheus datasource reference to
+  `{ type: "prometheus", uid: "victoriametrics" }` (the Grafana
+  built-in `"-- Grafana --"` annotation and `null` datasources are
+  preserved). The rewrite uses the recursive `(.. | objects | select(has("datasource")))`
+  `jq` update pattern — the same approach as the UniFi transform, no
+  `walk` dependency.
+- **Result**: a single `litellm.json` placed in a `runCommand` output
+  dir consumed by the Grafana file provider (folder `AI`).
+
+To refresh the upstream dashboard, run `nix run nixpkgs#nvfetcher`
+(which updates only the LiteLLM entry's pinned commit/hash — note it
+also re-checks every other nvfetcher source) and review the resulting
+`_sources/generated.nix` diff.

--- a/modules/myconfig.observability/dashboards/litellm-local.json
+++ b/modules/myconfig.observability/dashboards/litellm-local.json
@@ -66,7 +66,7 @@
       "type": "timeseries",
       "title": "Failure rate (failed / total requests)",
       "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-      "description": "Ratio of failed to total proxy requests. clamp_min avoids division by zero when there is no traffic.",
+      "description": "Ratio of failed to total proxy requests. clamp_min with a near-zero floor avoids division by zero when there is no traffic, without distorting the ratio at low request rates.",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
       "fieldConfig": {
         "defaults": {
@@ -81,7 +81,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(litellm_proxy_failed_requests_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])) / clamp_min(sum(rate(litellm_proxy_total_requests_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])), 1)",
+          "expr": "sum(rate(litellm_proxy_failed_requests_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])) / clamp_min(sum(rate(litellm_proxy_total_requests_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])), 1e-9)",
           "legendFormat": "failure rate",
           "refId": "A",
           "range": true
@@ -172,11 +172,11 @@
     {
       "id": 106,
       "type": "timeseries",
-      "title": "LiteLLM overhead latency p50 / p95 (ms)",
+      "title": "LiteLLM overhead latency p50 / p95 (s)",
       "datasource": { "type": "prometheus", "uid": "victoriametrics" },
-      "description": "Proxy processing overhead. The overhead metric exposes the model_group label (same values as requested_model), so $model filters on model_group here.",
+      "description": "Proxy processing overhead, in seconds (the upstream metric docstring claims milliseconds, but the histogram shares the same second-based latency buckets as the other latency metrics). The overhead metric exposes the model_group label (same values as requested_model), so $model filters on model_group here.",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 17 },
-      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
         "tooltip": { "mode": "multi", "sort": "none" }

--- a/modules/myconfig.observability/dashboards/litellm-local.json
+++ b/modules/myconfig.observability/dashboards/litellm-local.json
@@ -1,0 +1,338 @@
+{
+  "variables": [
+    {
+      "name": "host",
+      "label": "host",
+      "type": "query",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "query": "label_values(litellm_proxy_total_requests_metric_total, host)",
+      "refresh": 2,
+      "includeAll": true,
+      "multi": true,
+      "sort": 1,
+      "hide": 0,
+      "skipUrlSync": false,
+      "options": [],
+      "current": { "selected": true, "text": "All", "value": "$__all" }
+    },
+    {
+      "name": "model",
+      "label": "model",
+      "type": "query",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "query": "label_values(litellm_proxy_total_requests_metric_total{host=~\"$host\"}, requested_model)",
+      "refresh": 2,
+      "includeAll": true,
+      "multi": true,
+      "sort": 1,
+      "hide": 0,
+      "skipUrlSync": false,
+      "options": [],
+      "current": { "selected": true, "text": "All", "value": "$__all" }
+    }
+  ],
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "LiteLLM operational observability (local additions)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 101,
+      "type": "timeseries",
+      "title": "Requests / s by model",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Proxy request rate grouped by requested model.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max", "mean"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (requested_model) (rate(litellm_proxy_total_requests_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{requested_model}}",
+          "refId": "A",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 102,
+      "type": "timeseries",
+      "title": "Failure rate (failed / total requests)",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Ratio of failed to total proxy requests. clamp_min avoids division by zero when there is no traffic.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 0.05 }, { "color": "red", "value": 0.2 } ] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(litellm_proxy_failed_requests_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])) / clamp_min(sum(rate(litellm_proxy_total_requests_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])), 1)",
+          "legendFormat": "failure rate",
+          "refId": "A",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 103,
+      "type": "timeseries",
+      "title": "Total request latency p50 / p95 (s)",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "End-to-end proxy request latency percentiles from the litellm_request_total_latency_metric histogram buckets.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, requested_model) (rate(litellm_request_total_latency_metric_bucket{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{requested_model}}",
+          "refId": "A",
+          "range": true
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, requested_model) (rate(litellm_request_total_latency_metric_bucket{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{requested_model}}",
+          "refId": "B",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 104,
+      "type": "timeseries",
+      "title": "LLM API latency p50 / p95 (s)",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Upstream LLM API call latency percentiles from the litellm_llm_api_latency_metric histogram buckets.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, requested_model) (rate(litellm_llm_api_latency_metric_bucket{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{requested_model}}",
+          "refId": "A",
+          "range": true
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, requested_model) (rate(litellm_llm_api_latency_metric_bucket{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{requested_model}}",
+          "refId": "B",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 105,
+      "type": "timeseries",
+      "title": "Time to first token p50 / p95 (s)",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Time-to-first-token percentiles from the litellm_llm_api_time_to_first_token_metric histogram buckets.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 17 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, requested_model) (rate(litellm_llm_api_time_to_first_token_metric_bucket{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{requested_model}}",
+          "refId": "A",
+          "range": true
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, requested_model) (rate(litellm_llm_api_time_to_first_token_metric_bucket{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{requested_model}}",
+          "refId": "B",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 106,
+      "type": "timeseries",
+      "title": "LiteLLM overhead latency p50 / p95 (ms)",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Proxy processing overhead. The overhead metric exposes the model_group label (same values as requested_model), so $model filters on model_group here.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 17 },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, model_group) (rate(litellm_overhead_latency_metric_bucket{host=~\"$host\",model_group=~\"$model\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{model_group}}",
+          "refId": "A",
+          "range": true
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, model_group) (rate(litellm_overhead_latency_metric_bucket{host=~\"$host\",model_group=~\"$model\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{model_group}}",
+          "refId": "B",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 107,
+      "type": "timeseries",
+      "title": "Input tokens / s by model",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Input (prompt) token rate grouped by requested model.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (requested_model) (rate(litellm_input_tokens_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{requested_model}}",
+          "refId": "A",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 108,
+      "type": "timeseries",
+      "title": "Output tokens / s by model",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Output (completion) token rate grouped by requested model.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (requested_model) (rate(litellm_output_tokens_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{requested_model}}",
+          "refId": "A",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 109,
+      "type": "timeseries",
+      "title": "Total tokens / s by model",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Total token rate (input + output) grouped by requested model.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (requested_model) (rate(litellm_total_tokens_metric_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{requested_model}}",
+          "refId": "A",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 110,
+      "type": "timeseries",
+      "title": "Deployment state (0 healthy / 1 partial / 2 outage)",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Per-deployment health gauge. litellm_deployment_state has no requested_model label, so it is filtered by host only; the legend shows the underlying model name and provider.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0, "max": 2 }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "litellm_deployment_state{host=~\"$host\"}",
+          "legendFormat": "{{litellm_model_name}} ({{api_provider}})",
+          "refId": "A",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 111,
+      "type": "timeseries",
+      "title": "Deployment success vs failure / s",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Successful and failed LLM API deployment responses per second, grouped by underlying model name and filtered by requested model.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 41 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (litellm_model_name) (rate(litellm_deployment_success_responses_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "ok {{litellm_model_name}}",
+          "refId": "A",
+          "range": true
+        },
+        {
+          "expr": "sum by (litellm_model_name) (rate(litellm_deployment_failure_responses_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "fail {{litellm_model_name}}",
+          "refId": "B",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 112,
+      "type": "timeseries",
+      "title": "Fallbacks / s (successful vs failed)",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "description": "Model fallback rate. Where no fallbacks are configured these counters are absent and the panel shows no data.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 49 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (requested_model, fallback_model) (rate(litellm_deployment_successful_fallbacks_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "ok {{requested_model}} -> {{fallback_model}}",
+          "refId": "A",
+          "range": true
+        },
+        {
+          "expr": "sum by (requested_model, fallback_model) (rate(litellm_deployment_failed_fallbacks_total{host=~\"$host\",requested_model=~\"$model\"}[$__rate_interval]))",
+          "legendFormat": "fail {{requested_model}} -> {{fallback_model}}",
+          "refId": "B",
+          "range": true
+        }
+      ]
+    }
+  ]
+}

--- a/modules/myconfig.observability/dashboards/litellm-rewrite.jq
+++ b/modules/myconfig.observability/dashboards/litellm-rewrite.jq
@@ -1,0 +1,134 @@
+# LiteLLM Grafana dashboard — build-time rewrite program (jq).
+#
+# Consumed by modules/myconfig.observability/host.litellm.nix. The upstream
+# dashboard JSON (pinned via nvfetcher, see _sources/generated.nix) is piped
+# through this program; the local additions fragment
+# (modules/myconfig.observability/dashboards/litellm-local.json) is slurped
+# with `--slurpfile local` so it is available here as `$local[0]`.
+#
+# The rewrite is intentionally conservative so an unrelated upstream datasource
+# (Loki/Tempo/etc.) is never silently rewritten to Prometheus, and so an
+# upstream restructure fails the build loudly (see the assertions at the end)
+# rather than producing a silently incomplete dashboard.
+#
+# Steps:
+#   1. Strip Grafana import metadata and pin a local identity (uid/title/tags).
+#   2. Drop the upstream `DS_PROMETHEUS` datasource template variable.
+#   3. Remove panels that depend on LiteLLM virtual keys / teams /
+#      database-backed spend — this deployment runs no LiteLLM database, so
+#      those metrics (grouped by `api_key_alias` / `team_alias`, or
+#      `litellm_spend_metric_total`) are never populated. Matching combines a
+#      stable-title substring with PromQL-label usage so upstream renames are
+#      still caught; panel position is not relied upon.
+#   4. Rewrite only *known Prometheus* datasource references (string or object
+#      form) to the local VictoriaMetrics instance (uid `victoriametrics`).
+#      The Grafana built-in annotation datasource (`-- Grafana --`, string or
+#      object) and `null` datasource values are preserved, as are any
+#      unrelated datasource types.
+#   5. Rewrite upstream PromQL: fix two legacy gauge names the pinned upstream
+#      still references, insert a `host=~"$host"` selector into every
+#      `litellm_*` metric (all scraped series carry the `host` external label
+#      via vmagent), and switch the fixed `[2m]` window to `$__rate_interval`.
+#      Model filtering is NOT blanket-applied here (not every metric exposes
+#      the `requested_model` label); the locally maintained panels below add
+#      it where the metric supports it.
+#   6. Append the local additions (the `$host` and `$model` template variables
+#      plus the locally maintained operational panels) from the slurped
+#      fragment, offsetting the local panels below the last upstream panel so
+#      nothing overlaps regardless of upstream drift.
+#   7. Assert the final structure so an upstream change that breaks the
+#      assumptions fails the build instead of shipping a broken dashboard.
+
+# ── 1. Strip import metadata & pin local identity ──
+del(.__inputs, .__requires)
+| .id = null
+| .uid = "myconfig-litellm"
+| .title = "LiteLLM"
+| .tags = ((.tags // []) + [ "myconfig", "litellm", "llm" ] | unique)
+
+# ── 2. Drop the upstream DS_PROMETHEUS datasource variable ──
+# Panels no longer reference $DS_PROMETHEUS after step 4.
+| .templating.list = [ .templating.list[]? | select(.name != "DS_PROMETHEUS") ]
+
+# ── 3. Remove key / team / spend panels ──
+| .panels = [
+    .panels[]
+    | select(
+        (
+          ( (.title // "") | test("Virtual Key and Team|by Key Alias|by Team Alias|spend"; "i") )
+          or
+          ( [ .targets[]?.expr // empty ]
+            | map(test("api_key_alias|team_alias|litellm_spend_metric"))
+            | any )
+        ) | not
+      )
+  ]
+
+# ── 4. Rewrite Prometheus datasource references to VictoriaMetrics ──
+| (.. | objects | select(has("datasource"))) |=
+    ( .datasource =
+        ( if (.datasource | type) == "string" then
+            ( if   .datasource == "${DS_PROMETHEUS}"
+                 or .datasource == "$DS_PROMETHEUS"
+                 or (.datasource | ascii_downcase) == "prometheus"
+              then { type: "prometheus", uid: "victoriametrics" }
+              else .datasource end )
+          elif (.datasource | type) == "object" then
+            ( if   (.datasource.type // "") == "prometheus"
+                 or (.datasource.uid // "") == "${DS_PROMETHEUS}"
+                 or (.datasource.uid // "") == "$DS_PROMETHEUS"
+              then { type: "prometheus", uid: "victoriametrics" }
+              else .datasource end )
+          else .datasource end ) )
+
+# ── 5. Rewrite upstream PromQL ──
+# 5a. The pinned upstream references legacy gauge names without the `_metric`
+#     suffix; the deployed LiteLLM version emits `litellm_remaining_requests_metric`
+#     and `litellm_remaining_tokens_metric`. The negative lookahead avoids
+#     double-suffixing an already-correct name.
+# 5b. Insert `host=~"$host"` into every litellm_* metric selector (bare, with
+#     an existing `{...}`, or with a `[range]`). The `(?!host=)` lookahead and
+#     the bare-match lookahead prevent inserting twice. Only the `host` label
+#     is added here; `requested_model` filtering belongs to the local panels.
+# 5c. Use Grafana's `$__rate_interval` instead of the upstream's fixed `[2m]`.
+| (.. | objects | select(has("expr"))?) |=
+    ( .expr =
+        ( (.expr // "")
+          | gsub("litellm_remaining_requests(?![A-Za-z0-9_])"; "litellm_remaining_requests_metric")
+          | gsub("litellm_remaining_tokens(?![A-Za-z0-9_])"; "litellm_remaining_tokens_metric")
+          | gsub("(?<m>litellm_[A-Za-z0-9_]+)\\["; "\(.m){host=~\"$host\"}[")
+          | gsub("(?<m>litellm_[A-Za-z0-9_]+)\\{(?!host=)(?<b>[^}]*)\\}"; "\(.m){host=~\"$host\",\(.b)}")
+          | gsub("(?<m>litellm_[A-Za-z0-9_]+)(?![A-Za-z0-9_\\[{])"; "\(.m){host=~\"$host\"}")
+          | gsub("\\[2m\\]"; "[$__rate_interval]") ) )
+
+# ── 6. Append local additions (variables + panels) ──
+# $local is the slurped local fragment; $local[0] = { variables, panels }.
+# Local panels use relative gridPos.y; offset them below the last upstream
+# panel (max y+h) so nothing overlaps regardless of upstream drift.
+| ( [ .panels[] | ((.gridPos.y // 0) + (.gridPos.h // 0)) ] | max ) as $maxy
+| .templating.list = .templating.list + $local[0].variables
+| .panels = .panels + ( $local[0].panels | map(.gridPos.y = ((.gridPos.y // 0) + $maxy)) )
+
+# ── 7. Drift / structural assertions ──
+| if (.panels | type) != "array" or (.panels | length) == 0
+  then error("LiteLLM dashboard: no panels array (upstream structure changed?)") else . end
+| if (.title // "") == ""
+  then error("LiteLLM dashboard: missing title") else . end
+| if ([.templating.list[]?.name] | index("host") | not)
+  then error("LiteLLM dashboard: $host variable missing") else . end
+| if ([.templating.list[]?.name] | index("model") | not)
+  then error("LiteLLM dashboard: $model variable missing") else . end
+| if ([.. | objects | select(has("datasource")) | .datasource.uid // empty]
+        | any(. == "victoriametrics") | not)
+  then error("LiteLLM dashboard: no victoriametrics datasource reference") else . end
+| if ([.. | objects | select(has("expr")) | .expr // empty] | any(test("litellm_")) | not)
+  then error("LiteLLM dashboard: no LiteLLM PromQL target found") else . end
+| if ([.panels[] | select(.targets) | .targets[].expr // empty]
+        | any(test("litellm_proxy_total_requests_metric")) | not)
+  then error("LiteLLM dashboard: no request panel") else . end
+| if ([.panels[] | select(.targets) | .targets[].expr // empty]
+        | any(test("litellm_proxy_failed_requests_metric")) | not)
+  then error("LiteLLM dashboard: no failure panel") else . end
+| if ([.panels[] | select(.targets) | .targets[].expr // empty]
+        | any(test("_bucket|histogram_quantile")) | not)
+  then error("LiteLLM dashboard: no latency panel") else . end

--- a/modules/myconfig.observability/host.litellm.nix
+++ b/modules/myconfig.observability/host.litellm.nix
@@ -5,51 +5,81 @@
 #
 # The metrics themselves are produced by the LiteLLM service running on
 # any client where `services.litellm.enable = true` and
-# `myconfig.observability.client.enable = true` — the client module
-# wraps the litellm package with `prometheus_client` and registers the
-# `prometheus` callback (see modules/myconfig.ai/services.litellm.nix).
-# The local vmagent on the client scrapes
-# `http://<litellm host>:<port>/metrics/` (job=`litellm`) and pushes into
-# the central VictoriaMetrics instance via remote_write.
+# `myconfig.observability.client.enable = true` — the client module wraps the
+# litellm package with `prometheus_client` and registers the `prometheus`
+# callback (see modules/myconfig.ai/services.litellm.nix). The local vmagent
+# on the client scrapes `http://<litellm host>:<port>/metrics/` (job=`litellm`,
+# note the trailing slash — the bare `/metrics` endpoint redirects with HTTP
+# 307) and remote-writes into the central VictoriaMetrics instance. vmagent
+# attaches a `host` label to every series via `external_labels`, so every
+# LiteLLM metric carries `host=<hostname>` in VictoriaMetrics.
 #
-# This module only runs on the observability *host* (where Grafana is)
-# and provisions a dashboard so the metrics are immediately visualised.
+# This module only runs on the observability *host* (where Grafana is) and
+# provisions a dashboard so the metrics are immediately visualised.
 #
-# ─── Dashboard source ────────────────────────────────────────────────
+# ─── Dashboard source: upstream + local additions ─────────────────────
 #
 # Rather than hand-maintaining panel JSON, this module provisions the
-# *upstream* LiteLLM Grafana dashboard:
+# *upstream* LiteLLM Grafana dashboard, pinned through `nvfetcher.toml`
+# (entry `litellm-grafana-dashboard`). That source tracks LiteLLM's `main`
+# branch but `fetch.url` downloads *only* the dashboard JSON from the exact
+# immutable Git commit nvfetcher resolves (see `_sources/generated.nix`,
+# regenerated with `nix run nixpkgs#nvfetcher`). The upstream JSON is never
+# committed to this repository.
 #
-#   https://github.com/BerriAI/litellm/blob/main/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json
+# The upstream dashboard is not usable as-is for this deployment, so it is
+# rewritten at Nix build time with `jq` (the rewrite program lives in
+# ./dashboards/litellm-rewrite.jq). The rewrite:
 #
-# The source is pinned through `nvfetcher.toml` (entry
-# `litellm-grafana-dashboard`), which tracks LiteLLM's `main` branch but
-# fetches *only* the dashboard JSON from the exact Git commit it resolves.
-# The immutable commit and its hash live in `_sources/generated.nix`
-# (regenerated with `nix run nixpkgs#nvfetcher`). The upstream JSON is
-# never committed to this repository.
+#   * strips Grafana import metadata and pins a stable dashboard identity
+#     (`uid = "myconfig-litellm"`, `title = "LiteLLM"`, local tags) so
+#     rebuilds update the same dashboard row instead of cloning it;
+#   * drops the upstream `DS_PROMETHEUS` datasource template variable and
+#     rewrites every *Prometheus* datasource reference (string or object
+#     form) to `{ type: "prometheus", uid: "victoriametrics" }` — the local
+#     VictoriaMetrics datasource. Only Prometheus references are rewritten, so
+#     a future Loki/Tempo/etc. datasource is left untouched. Grafana's
+#     built-in `-- Grafana --` annotation datasource and `null` datasources
+#     are preserved;
+#   * removes panels that depend on LiteLLM virtual keys / teams /
+#     database-backed spend (`api_key_alias`, `team_alias`,
+#     `litellm_spend_metric_total`) — this deployment runs no LiteLLM
+#     database, so those panels would always be empty;
+#   * inserts a `host=~"$host"` selector into every upstream LiteLLM PromQL
+#     target (every scraped series carries the `host` external label) and
+#     switches the fixed `[2m]` window to `$__rate_interval`. It also fixes
+#     two legacy gauge names the pinned upstream still references.
 #
-# At Nix build time the JSON is rewritten with `jq` (see
-# `dashboardRewriteJq` below) so it drops import metadata, pins a stable
-# dashboard UID, removes panels that depend on features this deployment
-# does not run, and points every Prometheus datasource reference at the
-# local VictoriaMetrics instance (datasource UID `victoriametrics`).
+# The upstream dashboard aggregates globally and has no host/model filters,
+# only p50 (not p95) latency, and no token/TTFT/deployment/overhead panels.
+# Those views are therefore added as locally maintained panels, defined in
+# ./dashboards/litellm-local.json (a small repository-owned fragment — *not* a
+# copy of the upstream dashboard) and appended by the rewrite. The fragment
+# also contributes the `$host` and `$model` template variables:
+#
+#   * `$host`  — `label_values(litellm_proxy_total_requests_metric_total, host)`,
+#     multi-select with an `All` option defaulting to all hosts, so multiple
+#     LiteLLM hosts are never silently aggregated together;
+#   * `$model` — `label_values(litellm_proxy_total_requests_metric_total{host=~"$host"},
+#     requested_model)`, depending on `$host`, multi-select with an `All`
+#     option. `requested_model` is the model-group label LiteLLM emits on the
+#     request/latency/token/deployment metrics (verified against the pinned
+#     LiteLLM source). The overhead metric exposes `model_group` instead
+#     (same values as `requested_model`), so its panel filters on `model_group`.
+#
+# The rewrite ends with structural assertions (see litellm-rewrite.jq) so that
+# an upstream change violating the assumptions fails the build loudly instead
+# of shipping a silently incomplete dashboard. `jq -e .` additionally fails
+# the build on invalid input or output JSON.
 #
 # ─── No PostgreSQL / database required ───────────────────────────────
 #
 # The operational Prometheus metrics (request rates, latency histograms,
-# token throughput, deployment health) are emitted by LiteLLM's
-# `prometheus` callback and need *no* database. Accordingly this module
-# introduces no PostgreSQL, Prisma, virtual-key, team, or spend-log
-# configuration. The upstream dashboard ships some panels that *do*
-# depend on virtual keys / teams (grouped under the "LiteLLM Metrics by
-# Virtual Key and Team" row, e.g. "Requests per second by Key Alias" /
-# "... by Team Alias", which group by the `api_key_alias` / `team_alias`
-# labels). Those panels — and that collapsed row — are stripped by the
-# build-time rewrite, so the provisioned dashboard may show fewer panels
-# than the upstream file. Spend-related panels are absent upstream too.
-# Enable a LiteLLM database only if you need budget/spend/key features;
-# it is out of scope for this module.
+# token throughput, deployment health) are emitted by LiteLLM's `prometheus`
+# callback and need *no* database. Accordingly this module introduces no
+# PostgreSQL, Prisma, virtual-key, team, or spend-log configuration. Spend
+# logs remain disabled (services.litellm.settings.general_settings.
+# disable_spend_logs = true, set in modules/myconfig.ai/services.litellm.nix).
 {
   config,
   lib,
@@ -66,71 +96,17 @@ let
   sources = pkgs.callPackage ../../_sources/generated.nix { };
   upstreamDashboard = sources.litellm-grafana-dashboard.src;
 
-  # ─── Build-time dashboard rewrite ────────────────────────────────
-  # The upstream dashboard references a Prometheus datasource through the
-  # `${DS_PROMETHEUS}` template variable and declares its own UID/title.
-  # We rewrite it so it is self-contained for this deployment:
-  #
-  #   1. Strip `__inputs` / `__requires` (defensive — absent upstream).
-  #   2. Clear the numeric Grafana DB id (let Grafana assign locally).
-  #   3. Pin a stable `uid` so rebuilds update the same dashboard row.
-  #   4. Localise title / tags.
-  #   5. Drop the `DS_PROMETHEUS` datasource template variable (panels
-  #      no longer reference `$DS_PROMETHEUS` after the rewrite below).
-  #   6. Remove panels only useful with virtual keys / teams /
-  #      database-backed accounting (see header). Matching by title
-  #      substring *and* by PromQL label usage survives upstream renames.
-  #   7. Rewrite every Prometheus datasource reference (string or object
-  #      form) to `{ type: "prometheus", uid: "victoriametrics" }`.
-  #      The Grafana built-in annotation datasource
-  #      (`{ type: "grafana", uid: "-- Grafana --" }`, and the string
-  #      `"-- Grafana --"`) and `null` datasource values are preserved.
-  #
-  # Uses the recursive `(.. | objects | select(has("datasource")))` update
-  # pattern (built-in `jq`, no `walk` dependency) — the same approach as
-  # the UniFi dashboard rewrite in `host.unifi.nix`.
-  dashboardRewriteJq = pkgs.writeText "litellm-dashboard-rewrite.jq" ''
-    del(.__inputs, .__requires)
-    | .id = null
-    | .uid = "myconfig-litellm"
-    | .title = "LiteLLM"
-    | .tags = ((.tags // []) + [ "myconfig", "litellm", "llm" ] | unique)
-    # Drop the DS_PROMETHEUS datasource template variable: panels no
-    # longer reference $DS_PROMETHEUS after the rewrite below.
-    | .templating.list = [ .templating.list[]? | select(.name != "DS_PROMETHEUS") ]
-    # Remove panels that are only useful with LiteLLM virtual keys /
-    # teams / database-backed accounting, which this deployment does not
-    # run (see the module header comment). Match by title substring and
-    # by PromQL label usage so upstream renames are still caught.
-    | .panels = [
-        .panels[]
-        | select(
-            (
-              ( (.title // "") | test("Virtual Key and Team|by Key Alias|by Team Alias"; "i") )
-              or
-              ( [ .targets[]?.expr // empty ]
-                | map(test("api_key_alias|team_alias"))
-                | any )
-            ) | not
-          )
-      ]
-    # Rewrite every datasource field to the local VictoriaMetrics instance,
-    # preserving the Grafana built-in annotation datasource and null values.
-    | (.. | objects | select(has("datasource"))) |=
-        ( .datasource =
-            ( if (.datasource | type) == "string"
-              then ( if .datasource == "-- Grafana --" then .datasource
-                     else { type: "prometheus", uid: "victoriametrics" } end )
-              elif .datasource == null then null
-              elif (.datasource.type // "") == "prometheus"
-              then { type: "prometheus", uid: "victoriametrics" }
-              else .datasource
-              end ) )
-  '';
+  # Build-time dashboard rewrite (see ./dashboards/litellm-rewrite.jq) plus
+  # the locally maintained additions (./dashboards/litellm-local.json). Both
+  # are committed, reviewable files; the Nix store path is taken via the
+  # relative path so a `git add` is required for Nix to see them.
+  rewriteJq = ./dashboards/litellm-rewrite.jq;
+  localFragment = ./dashboards/litellm-local.json;
 
   # Produce the final dashboard directory consumed by the Grafana file
-  # provider. `jq -e .` fails the build if the upstream file or the
-  # transformed output is not valid JSON.
+  # provider. `jq -f` applies the rewrite (slurping the local fragment with
+  # `--slurpfile local`); the rewrite's own assertions fail the build on
+  # upstream drift, and the trailing `jq -e .` fails it on invalid JSON.
   dashboardsDir =
     pkgs.runCommand "myconfig-litellm-dashboards"
       {
@@ -138,7 +114,8 @@ let
       }
       ''
         mkdir -p "$out"
-        jq -f ${dashboardRewriteJq} ${upstreamDashboard} > "$out/litellm.json"
+        jq --slurpfile local ${localFragment} -f ${rewriteJq} ${upstreamDashboard} \
+          > "$out/litellm.json"
         jq -e . "$out/litellm.json" > /dev/null
       '';
 in
@@ -150,9 +127,10 @@ in
       description = ''
         Provision a Grafana dashboard for the LiteLLM proxy metrics
         (job=`litellm`, scraped by vmagent on every host that runs
-        `services.litellm`). The dashboard is the upstream LiteLLM
-        Grafana dashboard, pinned via `nvfetcher` and rewritten at
-        build time to use the local VictoriaMetrics datasource.
+        `services.litellm`). The dashboard is the upstream LiteLLM Grafana
+        dashboard, pinned via `nvfetcher` and rewritten at build time to use
+        the local VictoriaMetrics datasource with host/model filtering and
+        locally maintained operational panels.
       '';
     };
   };
@@ -167,7 +145,9 @@ in
           disableDeletion = true;
           updateIntervalSeconds = 60;
           # Group the dashboard under an "AI" folder in the Grafana UI
-          # sidebar (created on first sync if missing).
+          # sidebar (created on first sync if missing). The stable
+          # `uid = "myconfig-litellm"` (pinned by the rewrite) means rebuilds
+          # update the same dashboard row instead of creating duplicates.
           folder = "AI";
           options.path = dashboardsDir;
         }

--- a/modules/myconfig.observability/host.litellm.nix
+++ b/modules/myconfig.observability/host.litellm.nix
@@ -9,11 +9,47 @@
 # wraps the litellm package with `prometheus_client` and registers the
 # `prometheus` callback (see modules/myconfig.ai/services.litellm.nix).
 # The local vmagent on the client scrapes
-# `http://<litellm host>:<port>/metrics` (job=`litellm`) and pushes into
+# `http://<litellm host>:<port>/metrics/` (job=`litellm`) and pushes into
 # the central VictoriaMetrics instance via remote_write.
 #
 # This module only runs on the observability *host* (where Grafana is)
 # and provisions a dashboard so the metrics are immediately visualised.
+#
+# ─── Dashboard source ────────────────────────────────────────────────
+#
+# Rather than hand-maintaining panel JSON, this module provisions the
+# *upstream* LiteLLM Grafana dashboard:
+#
+#   https://github.com/BerriAI/litellm/blob/main/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json
+#
+# The source is pinned through `nvfetcher.toml` (entry
+# `litellm-grafana-dashboard`), which tracks LiteLLM's `main` branch but
+# fetches *only* the dashboard JSON from the exact Git commit it resolves.
+# The immutable commit and its hash live in `_sources/generated.nix`
+# (regenerated with `nix run nixpkgs#nvfetcher`). The upstream JSON is
+# never committed to this repository.
+#
+# At Nix build time the JSON is rewritten with `jq` (see
+# `dashboardRewriteJq` below) so it drops import metadata, pins a stable
+# dashboard UID, removes panels that depend on features this deployment
+# does not run, and points every Prometheus datasource reference at the
+# local VictoriaMetrics instance (datasource UID `victoriametrics`).
+#
+# ─── No PostgreSQL / database required ───────────────────────────────
+#
+# The operational Prometheus metrics (request rates, latency histograms,
+# token throughput, deployment health) are emitted by LiteLLM's
+# `prometheus` callback and need *no* database. Accordingly this module
+# introduces no PostgreSQL, Prisma, virtual-key, team, or spend-log
+# configuration. The upstream dashboard ships some panels that *do*
+# depend on virtual keys / teams (grouped under the "LiteLLM Metrics by
+# Virtual Key and Team" row, e.g. "Requests per second by Key Alias" /
+# "... by Team Alias", which group by the `api_key_alias` / `team_alias`
+# labels). Those panels — and that collapsed row — are stripped by the
+# build-time rewrite, so the provisioned dashboard may show fewer panels
+# than the upstream file. Spend-related panels are absent upstream too.
+# Enable a LiteLLM database only if you need budget/spend/key features;
+# it is out of scope for this module.
 {
   config,
   lib,
@@ -25,509 +61,86 @@ let
   hostCfg = cfg.host;
   litellmCfg = hostCfg.litellm;
 
-  # Grafana dashboard for LiteLLM proxy metrics.
-  litellmDashboard = {
-    uid = "myconfig-litellm";
-    title = "LiteLLM";
-    tags = [
-      "myconfig"
-      "llm"
-      "litellm"
-    ];
-    schemaVersion = 39;
-    version = 1;
-    timezone = "browser";
-    refresh = "30s";
-    time = {
-      from = "now-6h";
-      to = "now";
-    };
-    annotations.list = [ ];
-    templating.list = [
-      {
-        name = "host";
-        label = "host";
-        type = "query";
-        datasource = "VictoriaMetrics";
-        query = "label_values(litellm_proxy_total_requests_metric_total, host)";
-        refresh = 2;
-        includeAll = true;
-        multi = true;
-        sort = 1;
-      }
-      {
-        name = "model";
-        label = "model";
-        type = "query";
-        datasource = "VictoriaMetrics";
-        query = ''label_values(litellm_proxy_total_requests_metric_total{host=~"$host"}, model)'';
-        refresh = 2;
-        includeAll = true;
-        multi = true;
-        sort = 1;
-      }
-    ];
-    panels = [
-      # ------------------------------------------------------------------
-      # Row 0..6: top-line stats
-      # ------------------------------------------------------------------
-      {
-        id = 1;
-        type = "stat";
-        title = "Requests / s (proxy)";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 6;
-          w = 6;
-          x = 0;
-          y = 0;
-        };
-        options = {
-          reduceOptions = {
-            calcs = [ "lastNotNull" ];
-            fields = "";
-            values = false;
-          };
-          colorMode = "value";
-          graphMode = "area";
-          textMode = "auto";
-        };
-        fieldConfig.defaults = {
-          unit = "reqps";
-          decimals = 2;
-        };
-        targets = [
-          {
-            expr = ''sum(rate(litellm_proxy_total_requests_metric_total{host=~"$host"}[5m]))'';
-            legendFormat = "requests/s";
-            refId = "A";
-          }
-        ];
-      }
-      {
-        id = 2;
-        type = "stat";
-        title = "Failed requests / s";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 6;
-          w = 6;
-          x = 6;
-          y = 0;
-        };
-        options = {
-          reduceOptions = {
-            calcs = [ "lastNotNull" ];
-            fields = "";
-            values = false;
-          };
-          colorMode = "background";
-          graphMode = "area";
-          textMode = "auto";
-        };
-        fieldConfig.defaults = {
-          unit = "reqps";
-          decimals = 2;
-          thresholds = {
-            mode = "absolute";
-            steps = [
-              {
-                color = "green";
-                value = null;
-              }
-              {
-                color = "orange";
-                value = 0.001;
-              }
-              {
-                color = "red";
-                value = 0.1;
-              }
-            ];
-          };
-        };
-        targets = [
-          {
-            expr = ''sum(rate(litellm_proxy_failed_requests_metric_total{host=~"$host"}[5m]))'';
-            legendFormat = "failed/s";
-            refId = "A";
-          }
-        ];
-      }
-      {
-        id = 3;
-        type = "stat";
-        title = "Tokens / s (total)";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 6;
-          w = 6;
-          x = 12;
-          y = 0;
-        };
-        options = {
-          reduceOptions = {
-            calcs = [ "lastNotNull" ];
-            fields = "";
-            values = false;
-          };
-          colorMode = "value";
-          graphMode = "area";
-          textMode = "auto";
-        };
-        fieldConfig.defaults.unit = "short";
-        targets = [
-          {
-            expr = ''sum(rate(litellm_total_tokens_metric_total{host=~"$host"}[5m]))'';
-            legendFormat = "tokens/s";
-            refId = "A";
-          }
-        ];
-      }
-      {
-        id = 4;
-        type = "stat";
-        title = "Total spend ($)";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 6;
-          w = 6;
-          x = 18;
-          y = 0;
-        };
-        options = {
-          reduceOptions = {
-            calcs = [ "lastNotNull" ];
-            fields = "";
-            values = false;
-          };
-          colorMode = "value";
-          graphMode = "area";
-          textMode = "auto";
-        };
-        fieldConfig.defaults = {
-          unit = "currencyUSD";
-          decimals = 4;
-        };
-        targets = [
-          {
-            expr = ''sum(litellm_spend_metric_total{host=~"$host"})'';
-            legendFormat = "spend";
-            refId = "A";
-          }
-        ];
-      }
-      # ------------------------------------------------------------------
-      # Row 6..14: request rates per model
-      # ------------------------------------------------------------------
-      {
-        id = 10;
-        type = "timeseries";
-        title = "Requests / s by model";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 0;
-          y = 6;
-        };
-        fieldConfig.defaults.unit = "reqps";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [
-            "lastNotNull"
-            "max"
-            "mean"
-          ];
-        };
-        targets = [
-          {
-            expr = ''sum by (model) (rate(litellm_proxy_total_requests_metric_total{host=~"$host", model=~"$model"}[5m]))'';
-            legendFormat = "{{model}}";
-            refId = "A";
-          }
-        ];
-      }
-      {
-        id = 11;
-        type = "timeseries";
-        title = "Failed requests / s by model";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 12;
-          y = 6;
-        };
-        fieldConfig.defaults.unit = "reqps";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [
-            "lastNotNull"
-            "max"
-          ];
-        };
-        targets = [
-          {
-            expr = ''sum by (model, exception_class) (rate(litellm_proxy_failed_requests_metric_total{host=~"$host", model=~"$model"}[5m]))'';
-            legendFormat = "{{model}} / {{exception_class}}";
-            refId = "A";
-          }
-        ];
-      }
-      # ------------------------------------------------------------------
-      # Row 14..22: latency
-      # ------------------------------------------------------------------
-      {
-        id = 20;
-        type = "timeseries";
-        title = "Total request latency p50 / p95 (s)";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 0;
-          y = 14;
-        };
-        fieldConfig.defaults.unit = "s";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [ "lastNotNull" ];
-        };
-        targets = [
-          {
-            expr = ''histogram_quantile(0.50, sum by (le, model) (rate(litellm_request_total_latency_metric_bucket{host=~"$host", model=~"$model"}[5m])))'';
-            legendFormat = "p50 {{model}}";
-            refId = "A";
-          }
-          {
-            expr = ''histogram_quantile(0.95, sum by (le, model) (rate(litellm_request_total_latency_metric_bucket{host=~"$host", model=~"$model"}[5m])))'';
-            legendFormat = "p95 {{model}}";
-            refId = "B";
-          }
-        ];
-      }
-      {
-        id = 21;
-        type = "timeseries";
-        title = "LLM API latency p50 / p95 (s)";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 12;
-          y = 14;
-        };
-        fieldConfig.defaults.unit = "s";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [ "lastNotNull" ];
-        };
-        targets = [
-          {
-            expr = ''histogram_quantile(0.50, sum by (le, model) (rate(litellm_llm_api_latency_metric_bucket{host=~"$host", model=~"$model"}[5m])))'';
-            legendFormat = "p50 {{model}}";
-            refId = "A";
-          }
-          {
-            expr = ''histogram_quantile(0.95, sum by (le, model) (rate(litellm_llm_api_latency_metric_bucket{host=~"$host", model=~"$model"}[5m])))'';
-            legendFormat = "p95 {{model}}";
-            refId = "B";
-          }
-        ];
-      }
-      {
-        id = 22;
-        type = "timeseries";
-        title = "Time to first token p50 / p95 (s)";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 0;
-          y = 22;
-        };
-        fieldConfig.defaults.unit = "s";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [ "lastNotNull" ];
-        };
-        targets = [
-          {
-            expr = ''histogram_quantile(0.50, sum by (le, model) (rate(litellm_llm_api_time_to_first_token_metric_bucket{host=~"$host", model=~"$model"}[5m])))'';
-            legendFormat = "p50 {{model}}";
-            refId = "A";
-          }
-          {
-            expr = ''histogram_quantile(0.95, sum by (le, model) (rate(litellm_llm_api_time_to_first_token_metric_bucket{host=~"$host", model=~"$model"}[5m])))'';
-            legendFormat = "p95 {{model}}";
-            refId = "B";
-          }
-        ];
-      }
-      {
-        id = 23;
-        type = "timeseries";
-        title = "LiteLLM overhead latency (ms)";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 12;
-          y = 22;
-        };
-        fieldConfig.defaults.unit = "ms";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [ "lastNotNull" ];
-        };
-        targets = [
-          {
-            expr = ''histogram_quantile(0.50, sum by (le, model) (rate(litellm_overhead_latency_metric_bucket{host=~"$host", model=~"$model"}[5m])))'';
-            legendFormat = "p50 {{model}}";
-            refId = "A";
-          }
-          {
-            expr = ''histogram_quantile(0.95, sum by (le, model) (rate(litellm_overhead_latency_metric_bucket{host=~"$host", model=~"$model"}[5m])))'';
-            legendFormat = "p95 {{model}}";
-            refId = "B";
-          }
-        ];
-      }
-      # ------------------------------------------------------------------
-      # Row 30..38: token throughput
-      # ------------------------------------------------------------------
-      {
-        id = 30;
-        type = "timeseries";
-        title = "Input tokens / s by model";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 0;
-          y = 30;
-        };
-        fieldConfig.defaults.unit = "short";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [
-            "lastNotNull"
-            "mean"
-          ];
-        };
-        targets = [
-          {
-            expr = ''sum by (model) (rate(litellm_input_tokens_metric_total{host=~"$host", model=~"$model"}[5m]))'';
-            legendFormat = "{{model}}";
-            refId = "A";
-          }
-        ];
-      }
-      {
-        id = 31;
-        type = "timeseries";
-        title = "Output tokens / s by model";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 12;
-          y = 30;
-        };
-        fieldConfig.defaults.unit = "short";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [
-            "lastNotNull"
-            "mean"
-          ];
-        };
-        targets = [
-          {
-            expr = ''sum by (model) (rate(litellm_output_tokens_metric_total{host=~"$host", model=~"$model"}[5m]))'';
-            legendFormat = "{{model}}";
-            refId = "A";
-          }
-        ];
-      }
-      # ------------------------------------------------------------------
-      # Row 38..46: deployment health
-      # ------------------------------------------------------------------
-      {
-        id = 40;
-        type = "timeseries";
-        title = "Deployment state (0 healthy / 1 partial / 2 outage)";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 0;
-          y = 38;
-        };
-        fieldConfig.defaults = {
-          unit = "short";
-          min = 0;
-          max = 2;
-        };
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [ "lastNotNull" ];
-        };
-        targets = [
-          {
-            expr = ''litellm_deployment_state{host=~"$host"}'';
-            legendFormat = "{{litellm_model_name}} ({{api_provider}})";
-            refId = "A";
-          }
-        ];
-      }
-      {
-        id = 41;
-        type = "timeseries";
-        title = "Deployment success vs failure / s";
-        datasource = "VictoriaMetrics";
-        gridPos = {
-          h = 8;
-          w = 12;
-          x = 12;
-          y = 38;
-        };
-        fieldConfig.defaults.unit = "reqps";
-        options.legend = {
-          displayMode = "table";
-          placement = "bottom";
-          calcs = [
-            "lastNotNull"
-            "max"
-          ];
-        };
-        targets = [
-          {
-            expr = ''sum by (litellm_model_name) (rate(litellm_deployment_success_responses_total{host=~"$host"}[5m]))'';
-            legendFormat = "ok {{litellm_model_name}}";
-            refId = "A";
-          }
-          {
-            expr = ''sum by (litellm_model_name) (rate(litellm_deployment_failure_responses_total{host=~"$host"}[5m]))'';
-            legendFormat = "fail {{litellm_model_name}}";
-            refId = "B";
-          }
-        ];
-      }
-    ];
-  };
+  # nvfetcher-pinned upstream dashboard JSON (see header). `src` is a
+  # `fetchurl` store path pointing at the immutable-commit raw GitHub URL.
+  sources = pkgs.callPackage ../../_sources/generated.nix { };
+  upstreamDashboard = sources.litellm-grafana-dashboard.src;
 
-  litellmDashboardFile = pkgs.writeText "litellm-dashboard.json" (builtins.toJSON litellmDashboard);
+  # ─── Build-time dashboard rewrite ────────────────────────────────
+  # The upstream dashboard references a Prometheus datasource through the
+  # `${DS_PROMETHEUS}` template variable and declares its own UID/title.
+  # We rewrite it so it is self-contained for this deployment:
+  #
+  #   1. Strip `__inputs` / `__requires` (defensive — absent upstream).
+  #   2. Clear the numeric Grafana DB id (let Grafana assign locally).
+  #   3. Pin a stable `uid` so rebuilds update the same dashboard row.
+  #   4. Localise title / tags.
+  #   5. Drop the `DS_PROMETHEUS` datasource template variable (panels
+  #      no longer reference `$DS_PROMETHEUS` after the rewrite below).
+  #   6. Remove panels only useful with virtual keys / teams /
+  #      database-backed accounting (see header). Matching by title
+  #      substring *and* by PromQL label usage survives upstream renames.
+  #   7. Rewrite every Prometheus datasource reference (string or object
+  #      form) to `{ type: "prometheus", uid: "victoriametrics" }`.
+  #      The Grafana built-in annotation datasource
+  #      (`{ type: "grafana", uid: "-- Grafana --" }`, and the string
+  #      `"-- Grafana --"`) and `null` datasource values are preserved.
+  #
+  # Uses the recursive `(.. | objects | select(has("datasource")))` update
+  # pattern (built-in `jq`, no `walk` dependency) — the same approach as
+  # the UniFi dashboard rewrite in `host.unifi.nix`.
+  dashboardRewriteJq = pkgs.writeText "litellm-dashboard-rewrite.jq" ''
+    del(.__inputs, .__requires)
+    | .id = null
+    | .uid = "myconfig-litellm"
+    | .title = "LiteLLM"
+    | .tags = ((.tags // []) + [ "myconfig", "litellm", "llm" ] | unique)
+    # Drop the DS_PROMETHEUS datasource template variable: panels no
+    # longer reference $DS_PROMETHEUS after the rewrite below.
+    | .templating.list = [ .templating.list[]? | select(.name != "DS_PROMETHEUS") ]
+    # Remove panels that are only useful with LiteLLM virtual keys /
+    # teams / database-backed accounting, which this deployment does not
+    # run (see the module header comment). Match by title substring and
+    # by PromQL label usage so upstream renames are still caught.
+    | .panels = [
+        .panels[]
+        | select(
+            (
+              ( (.title // "") | test("Virtual Key and Team|by Key Alias|by Team Alias"; "i") )
+              or
+              ( [ .targets[]?.expr // empty ]
+                | map(test("api_key_alias|team_alias"))
+                | any )
+            ) | not
+          )
+      ]
+    # Rewrite every datasource field to the local VictoriaMetrics instance,
+    # preserving the Grafana built-in annotation datasource and null values.
+    | (.. | objects | select(has("datasource"))) |=
+        ( .datasource =
+            ( if (.datasource | type) == "string"
+              then ( if .datasource == "-- Grafana --" then .datasource
+                     else { type: "prometheus", uid: "victoriametrics" } end )
+              elif .datasource == null then null
+              elif (.datasource.type // "") == "prometheus"
+              then { type: "prometheus", uid: "victoriametrics" }
+              else .datasource
+              end ) )
+  '';
+
+  # Produce the final dashboard directory consumed by the Grafana file
+  # provider. `jq -e .` fails the build if the upstream file or the
+  # transformed output is not valid JSON.
+  dashboardsDir =
+    pkgs.runCommand "myconfig-litellm-dashboards"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+      }
+      ''
+        mkdir -p "$out"
+        jq -f ${dashboardRewriteJq} ${upstreamDashboard} > "$out/litellm.json"
+        jq -e . "$out/litellm.json" > /dev/null
+      '';
 in
 {
   options.myconfig.observability.host.litellm = with lib; {
@@ -537,24 +150,26 @@ in
       description = ''
         Provision a Grafana dashboard for the LiteLLM proxy metrics
         (job=`litellm`, scraped by vmagent on every host that runs
-        `services.litellm`).
+        `services.litellm`). The dashboard is the upstream LiteLLM
+        Grafana dashboard, pinned via `nvfetcher` and rewritten at
+        build time to use the local VictoriaMetrics datasource.
       '';
     };
   };
 
   config = lib.mkIf (hostCfg.enable && litellmCfg.provisionDashboard) {
     services.grafana.provision.dashboards.settings = {
-      apiVersion = 1;
+      apiVersion = lib.mkDefault 1;
       providers = [
         {
           name = "myconfig-litellm";
           type = "file";
           disableDeletion = true;
           updateIntervalSeconds = 60;
-          options.path = pkgs.runCommand "litellm-dashboards" { } ''
-            mkdir -p $out
-            cp ${litellmDashboardFile} $out/litellm.json
-          '';
+          # Group the dashboard under an "AI" folder in the Grafana UI
+          # sidebar (created on first sync if missing).
+          folder = "AI";
+          options.path = dashboardsDir;
         }
       ];
     };

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -1,13 +1,14 @@
 # nvfetcher source declarations.
 #
-# nvfetcher pins third-party GitHub sources (rev + hash) into the committed
-# `_sources/generated.nix`, which modules import via `pkgs.fetchFromGitHub`.
-# This keeps such pins *out* of `flake.lock` (so unrelated hosts are not
-# coupled to a shared lock entry) while still allowing automatic bumps: a
-# scheduled CI job runs `nvfetcher` and opens a PR when a rev/hash changes.
-#
-# Regenerate locally with:
-#   nix run nixpkgs#nvfetcher
+# nvfetcher generates fixed-output Nix sources in `_sources/generated.nix`
+# (regenerate locally with `nix run nixpkgs#nvfetcher`). Modules consume
+# those generated sources according to each source's fetch type: a
+# `fetch.github` entry is consumed via `pkgs.fetchFromGitHub`, while a
+# `fetch.url` entry (such as the LiteLLM dashboard JSON) is consumed via
+# `pkgs.fetchurl`. This keeps such pins *out* of `flake.lock` (so unrelated
+# hosts are not coupled to a shared lock entry) while still allowing automatic
+# bumps: a scheduled CI job runs `nvfetcher` and opens a PR when a rev/hash
+# changes.
 #
 # Each entry tracks the default branch of the given repo; the resolved rev and
 # hash are frozen in `_sources/generated.nix` until the next `nvfetcher` run.

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -17,3 +17,19 @@
 src.git = "https://github.com/grafana/skills"
 src.branch = "main"
 fetch.github = "grafana/skills"
+
+# Official LiteLLM Grafana dashboard.
+#
+# Track the tip of LiteLLM's main branch, but fetch only the dashboard JSON
+# from the exact commit resolved by nvfetcher. `src.git` (not `src.github`)
+# is used because the dashboard lives on `main`, not in a release. `$ver`
+# becomes the resolved Git commit, so the raw GitHub URL below is immutable.
+# `fetch.url` ensures the Nix store contains only the JSON file, not the
+# whole repository. Consumed by
+# modules/myconfig.observability/host.litellm.nix, which rewrites the
+# datasource references to the local VictoriaMetrics instance at build time.
+[litellm-grafana-dashboard]
+src.git = "https://github.com/BerriAI/litellm"
+src.branch = "main"
+fetch.url = "https://raw.githubusercontent.com/BerriAI/litellm/$ver/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json"
+url.name = "litellm-grafana-dashboard.json"


### PR DESCRIPTION
Replace the ~500-line inline hand-maintained LiteLLM dashboard with the upstream LiteLLM Grafana dashboard, pinned through nvfetcher and rewritten at build time. The new `litellm-grafana-dashboard` source in nvfetcher.toml tracks LiteLLM's `main` branch (`src.git`) but `fetch.url` downloads only the dashboard JSON from the exact commit nvfetcher resolves (`$ver` → immutable commit), so the Nix store holds a single immutable JSON file rather than a repository clone.

- The dashboard is rewritten with `jq` inside a `runCommand` (mirroring the UniFi dashboard rewrite in host.unifi.nix): strip `__inputs`/`__requires`, clear the numeric Grafana `id`, pin a stable `uid` (`myconfig-litellm`), localise title/tags, drop the `DS_PROMETHEUS` datasource template variable, remove panels that depend on virtual keys / teams / database-backed accounting (this deployment runs no database — they group by `api_key_alias`/`team_alias`), and rewrite every Prometheus datasource reference to `{ type: "prometheus", uid: "victoriametrics" }`. The Grafana built-in `"-- Grafana --"` annotation datasource and `null` datasource values are preserved. `jq -e .` fails the build on invalid JSON.
- Use the existing Grafana file provider with `apiVersion = lib.mkDefault 1` and an `AI` folder so multiple observability modules can contribute providers without conflict.
- Document the nvfetcher-based (non-vendored) approach in the dashboards README, separate from the committed UniFi dashboards.

Running `nix run nixpkgs#nvfetcher` also bumped `grafana-skills` (its `main` moved) as an incidental side effect of the regeneration. This is kept verbatim in the generated files so they stay idempotent across re-runs; it is safe (all skill paths referenced by grafana-core.nix still exist) and is unrelated to the LiteLLM change.

No PostgreSQL, Prisma, virtual-key, team, or spend-log configuration is introduced; spend logs remain disabled and vmagent still scrapes `/metrics/`.

supported by zai-org/GLM-5.2-TEE in pi