### PR TITLE
feat(ai): add ninfer-dockerized-Qwen3.8-27B-NVFP4 podman launch script

### DIFF
--- a/hosts/host.thing/default.nix
+++ b/hosts/host.thing/default.nix
@@ -58,7 +58,7 @@
     ./myconfig.ai.llama-cpp
     ./myconfig.observability.llama-swap-metrics.nix
     ./myconfig.ai.vllm
-    ./myconfig.ai.ninfer/docker.ninfer.cuda.nix
+    ./myconfig.ai.ninfer
     ./services.open-webui.nix
     # ./services.qdrant.nix
     ./services.litellm.nix
@@ -136,6 +136,9 @@
               "unsloth/Qwen3.8-27B-NVFP4"
               "sakamakismile/Qwen3.8-27B-MTP-NVFP4"
               "gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090"
+              # NInfer artifact (single .ninfer file, ~20 GiB) served by
+              # ./myconfig.ai.ninfer/docker.ninfer.cuda.nix.
+              "neroued/Qwen3.8-27B-nvfp4-NInfer"
             ];
           };
         };

--- a/hosts/host.thing/default.nix
+++ b/hosts/host.thing/default.nix
@@ -58,6 +58,7 @@
     ./myconfig.ai.llama-cpp
     ./myconfig.observability.llama-swap-metrics.nix
     ./myconfig.ai.vllm
+    ./myconfig.ai.ninfer/docker.ninfer.cuda.nix
     ./services.open-webui.nix
     # ./services.qdrant.nix
     ./services.litellm.nix

--- a/hosts/host.thing/default.nix
+++ b/hosts/host.thing/default.nix
@@ -130,17 +130,12 @@
           # entry stay declared here. Everything that *is* served by
           # llama-cpp is collected automatically from each model's
           # `pull-models = { target_directory; hf_spec; }` (see
-          # ./myconfig.ai.llama-cpp.nix).
-          models = {
-            "/home/mhuber/models" = [
-              "unsloth/Qwen3.8-27B-NVFP4"
-              "sakamakismile/Qwen3.8-27B-MTP-NVFP4"
-              "gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090"
-              # NInfer artifact (single .ninfer file, ~20 GiB) served by
-              # ./myconfig.ai.ninfer/docker.ninfer.cuda.nix.
-              "neroued/Qwen3.8-27B-nvfp4-NInfer"
-            ];
-          };
+          # ./myconfig.ai.llama-cpp.nix). The Docker/Podman-served vLLM
+          # and NInfer models declare their own `models` entries next to
+          # their variant definitions (./myconfig.ai.vllm/docker.vllm.cuda.nix,
+          # ./myconfig.ai.ninfer/docker.ninfer.cuda.nix) so a spec isn't
+          # silently left behind (and still downloaded) if its variant is
+          # ever dropped.
         };
         inference-cpp = {
           enable = true;

--- a/hosts/host.thing/myconfig.ai.ninfer/common.nix
+++ b/hosts/host.thing/myconfig.ai.ninfer/common.nix
@@ -96,7 +96,6 @@ let
           NINFER_GIT_REF="''${NINFER_GIT_REF:-${ninferGitRef}}"
           BUILD_IMAGE="''${BUILD_IMAGE:-1}"
 
-          # NInfer server settings.
           MAX_CONTEXT="''${MAX_CONTEXT:-${toString maxContext}}"
           KV_CAPACITY="''${KV_CAPACITY:-${kvCapacity}}"
           KV_DTYPE="''${KV_DTYPE:-${kvDtype}}"
@@ -180,7 +179,6 @@ let
             args+=(--vision)
           fi
 
-          # Append any positional arguments beyond the port.
           if [ ''${#EXTRA_ARGS[@]} -gt 0 ]; then
             args+=("''${EXTRA_ARGS[@]}")
           fi

--- a/hosts/host.thing/myconfig.ai.ninfer/common.nix
+++ b/hosts/host.thing/myconfig.ai.ninfer/common.nix
@@ -1,0 +1,191 @@
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+
+# Common NInfer Docker/Podman launch-script factory.
+#
+# NInfer (https://github.com/Neroued/ninfer) is a from-scratch C++/CUDA
+# inference engine for a closed set of registered Qwen checkpoints on a
+# single NVIDIA GeForce RTX 5090. It ships a Dockerfile but, as of this
+# writing, does not publish a prebuilt image to any registry — see
+# https://github.com/Neroued/ninfer/blob/master/Dockerfile and the "Docker"
+# section of the README. The default image reference below therefore
+# assumes a locally built image tagged `ninfer:local` (as documented
+# upstream: `docker build --tag ninfer:local .`); override via the
+# `DOCKER_IMAGE` env var if a different tag/registry is used.
+#
+# Each `.ninfer` artifact is a single file (not a directory checkout like
+# vLLM's Hugging Face repos), so the model is addressed as a host directory
+# (`modelHostDir`, bind-mounted read-only to `/models` in the container)
+# plus a `modelFilename` inside it.
+
+{ pkgs }:
+
+let
+  mkNinferDockerized =
+    {
+      containerRuntime ? "podman", # "docker" or "podman"
+
+      # --- Model ---
+      modelHostDir, # host directory containing the `.ninfer` artifact
+      modelFilename, # e.g. "qwen3_8_27b_nvfp4.ninfer"
+      servedModelName,
+      containerName,
+      port,
+
+      # --- NInfer server tuning knobs (null = use script default) ---
+      maxContext ? 252928,
+      kvCapacity ? "auto",
+      maxConcurrency ? 1,
+      spec ? "mtp",
+      draftTokens ? 3,
+      lmHeadDraft ? true,
+      vision ? false,
+
+      # Hugging Face repo + filename for on-demand download (null = skip)
+      modelHfRepo ? null,
+
+      extraConfig ? { },
+    }:
+    let
+      runtime = pkgs.${containerRuntime};
+      runtimeBin = "${runtime}/bin/${containerRuntime}";
+
+      ninferPkg = pkgs.writeShellApplication {
+        name = containerName;
+
+        runtimeInputs = [
+          pkgs.coreutils
+          runtime
+          (pkgs.python3.withPackages (ps: [ ps.huggingface-hub ]))
+        ];
+
+        text = ''
+          set -euo pipefail
+
+          # First argument is the optional host port; everything else
+          # is passed verbatim to the ninfer-serve CLI.
+          EXTRA_ARGS=()
+          if [ $# -gt 0 ]; then
+            HOST_PORT="$1"
+            shift
+            EXTRA_ARGS=("$@")
+          else
+            HOST_PORT="''${HOST_PORT:-${toString port}}"
+          fi
+
+          # Host-side model checkout (directory holding the .ninfer file).
+          MODEL_HOST_DIR="''${MODEL_HOST_DIR:-${modelHostDir}}"
+          MODEL_FILENAME="''${MODEL_FILENAME:-${modelFilename}}"
+
+          # Container settings.
+          DOCKER_IMAGE="''${DOCKER_IMAGE:-ninfer:local}"
+
+          # NInfer server settings.
+          MAX_CONTEXT="''${MAX_CONTEXT:-${toString maxContext}}"
+          KV_CAPACITY="''${KV_CAPACITY:-${kvCapacity}}"
+          MAX_CONCURRENCY="''${MAX_CONCURRENCY:-${toString maxConcurrency}}"
+          SPEC="''${SPEC:-${spec}}"
+          DRAFT_TOKENS="''${DRAFT_TOKENS:-${toString draftTokens}}"
+          LM_HEAD_DRAFT="''${LM_HEAD_DRAFT:-${if lmHeadDraft then "1" else "0"}}"
+          VISION="''${VISION:-${if vision then "1" else "0"}}"
+
+          REMOVE_EXISTING_CONTAINER="''${REMOVE_EXISTING_CONTAINER:-1}"
+
+          MODEL_HF_REPO="''${MODEL_HF_REPO:-${if modelHfRepo != null then modelHfRepo else ""}}"
+
+          if [ -n "$MODEL_HF_REPO" ]; then
+            echo "Ensuring model is present: $MODEL_HF_REPO/$MODEL_FILENAME" >&2
+            hf download "$MODEL_HF_REPO" "$MODEL_FILENAME" --local-dir "$MODEL_HOST_DIR"
+          fi
+
+          if [ ! -d "$MODEL_HOST_DIR" ]; then
+            echo "Model directory does not exist: $MODEL_HOST_DIR" >&2
+            exit 1
+          fi
+
+          if [ ! -f "$MODEL_HOST_DIR/$MODEL_FILENAME" ]; then
+            echo "Model artifact is missing: $MODEL_HOST_DIR/$MODEL_FILENAME" >&2
+            exit 1
+          fi
+
+          if [ "$REMOVE_EXISTING_CONTAINER" = "1" ]; then
+            if ${runtimeBin} ps -a --format '{{.Names}}' | grep -Fxq "${containerName}"; then
+              ${runtimeBin} rm -f "${containerName}" >/dev/null
+            fi
+          fi
+
+          args=(
+            ${runtimeBin} run
+            --rm
+            --device nvidia.com/gpu=all
+            --name "${containerName}"
+            --ipc=host
+            -p "$HOST_PORT:8080"
+            -v "$MODEL_HOST_DIR:/models:ro"
+            "$DOCKER_IMAGE"
+            ninfer-serve "/models/$MODEL_FILENAME"
+            --host 0.0.0.0
+            --port 8080
+            --max-context "$MAX_CONTEXT"
+            --kv-capacity "$KV_CAPACITY"
+            --max-concurrency "$MAX_CONCURRENCY"
+          )
+
+          if [ -n "$SPEC" ]; then
+            args+=(--spec "$SPEC" --draft-tokens "$DRAFT_TOKENS")
+          fi
+
+          if [ "$LM_HEAD_DRAFT" = "1" ]; then
+            args+=(--lm-head-draft)
+          fi
+
+          if [ "$VISION" = "1" ]; then
+            args+=(--vision)
+          fi
+
+          args+=(--model-id "${servedModelName}")
+
+          # Append any positional arguments beyond the port.
+          if [ ''${#EXTRA_ARGS[@]} -gt 0 ]; then
+            args+=("''${EXTRA_ARGS[@]}")
+          fi
+
+          if [ -n "''${EXTRA_NINFER_ARGS:-}" ]; then
+            # shellcheck disable=SC2206
+            extra_args=( $EXTRA_NINFER_ARGS )
+            args+=("''${extra_args[@]}")
+          fi
+
+          echo "Starting NInfer container:"
+          echo "  model:              $MODEL_HOST_DIR/$MODEL_FILENAME"
+          echo "  served model name:  ${servedModelName}"
+          echo "  endpoint:           http://localhost:$HOST_PORT/v1"
+          echo "  container image:    $DOCKER_IMAGE"
+          echo
+
+          set -x
+          exec "''${args[@]}"
+        '';
+      };
+    in
+    {
+      inherit ninferPkg;
+      modelConfig = {
+        "ninfer:${servedModelName}" = {
+          cmd = "${ninferPkg}/bin/${containerName}";
+          proxy = "http://127.0.0.1:${toString port}";
+          name = servedModelName;
+          useModelName = servedModelName;
+          aliases = [
+            servedModelName
+          ]
+          ++ (extraConfig.aliases or [ ]);
+          cmdStop = "${runtimeBin} stop ${containerName}";
+          ttl = 0;
+        };
+      };
+    };
+in
+{
+  inherit mkNinferDockerized;
+}

--- a/hosts/host.thing/myconfig.ai.ninfer/common.nix
+++ b/hosts/host.thing/myconfig.ai.ninfer/common.nix
@@ -1,7 +1,7 @@
 # Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
 # SPDX-License-Identifier: MIT
 
-# Common NInfer Docker/Podman launch-script factory.
+# Common NInfer Podman launch-script factory.
 #
 # NInfer (https://github.com/Neroued/ninfer) is a from-scratch C++/CUDA
 # inference engine for a closed set of registered Qwen checkpoints on a
@@ -9,14 +9,17 @@
 # writing, does not publish a prebuilt image to any registry — see
 # https://github.com/Neroued/ninfer/blob/master/Dockerfile and the "Docker"
 # section of the README. The default image reference below therefore
-# assumes a locally built image tagged `ninfer:local` (as documented
-# upstream: `docker build --tag ninfer:local .`); override via the
-# `DOCKER_IMAGE` env var if a different tag/registry is used.
+# assumes a locally built image tagged `ninfer:local`; when that image is
+# missing, the launch script itself builds it from a pinned upstream git
+# revision (`podman build git+https://github.com/Neroued/ninfer.git#<ref>:`)
+# so the variant is turnkey rather than requiring an out-of-band build step.
 #
 # Each `.ninfer` artifact is a single file (not a directory checkout like
 # vLLM's Hugging Face repos), so the model is addressed as a host directory
 # (`modelHostDir`, bind-mounted read-only to `/models` in the container)
-# plus a `modelFilename` inside it.
+# plus a `modelFilename` inside it. When the model card publishes a SHA-256
+# for the artifact, pass it as `modelSha256` so the script verifies the
+# download before every launch.
 
 { pkgs }:
 
@@ -28,14 +31,24 @@ let
       # --- Model ---
       modelHostDir, # host directory containing the `.ninfer` artifact
       modelFilename, # e.g. "qwen3_8_27b_nvfp4.ninfer"
-      servedModelName,
+      modelSha256 ? null, # published SHA-256 of the artifact; null skips verification
+      servedModelName, # human-readable name, e.g. "Qwen3.8-27B-NVFP4" (used for the
+      # llama-swap key/name/aliases, mirroring the vLLM `vllm:<Name>` convention)
+      modelId, # NInfer artifact identity.model_id, e.g. "qwen3.8-27b"
+      # (passed as --model-id and used as the OpenAI-facing model id)
       containerName,
       port,
+
+      # --- Engine image ---
+      # No registry distribution exists upstream; build locally from a
+      # pinned git revision when missing.
+      ninferGitRef, # pinned commit/tag of github.com/Neroued/ninfer
 
       # --- NInfer server tuning knobs (null = use script default) ---
       maxContext ? 252928,
       kvCapacity ? "auto",
-      maxConcurrency ? 1,
+      kvDtype ? "int8",
+      maxConcurrency ? 8,
       spec ? "mtp",
       draftTokens ? 3,
       lmHeadDraft ? true,
@@ -77,19 +90,27 @@ let
           MODEL_HOST_DIR="''${MODEL_HOST_DIR:-${modelHostDir}}"
           MODEL_FILENAME="''${MODEL_FILENAME:-${modelFilename}}"
 
-          # Container settings.
+          # Locally built NInfer image; built from a pinned upstream git
+          # revision on first use since there is no registry distribution.
           DOCKER_IMAGE="''${DOCKER_IMAGE:-ninfer:local}"
+          NINFER_GIT_REF="''${NINFER_GIT_REF:-${ninferGitRef}}"
+          BUILD_IMAGE="''${BUILD_IMAGE:-1}"
 
           # NInfer server settings.
           MAX_CONTEXT="''${MAX_CONTEXT:-${toString maxContext}}"
           KV_CAPACITY="''${KV_CAPACITY:-${kvCapacity}}"
+          KV_DTYPE="''${KV_DTYPE:-${kvDtype}}"
           MAX_CONCURRENCY="''${MAX_CONCURRENCY:-${toString maxConcurrency}}"
-          SPEC="''${SPEC:-${spec}}"
+          SPEC="''${SPEC-${spec}}"
           DRAFT_TOKENS="''${DRAFT_TOKENS:-${toString draftTokens}}"
           LM_HEAD_DRAFT="''${LM_HEAD_DRAFT:-${if lmHeadDraft then "1" else "0"}}"
           VISION="''${VISION:-${if vision then "1" else "0"}}"
 
           REMOVE_EXISTING_CONTAINER="''${REMOVE_EXISTING_CONTAINER:-1}"
+
+          # Published SHA-256 of the artifact (model card); empty skips.
+          MODEL_SHA256="''${MODEL_SHA256:-${if modelSha256 != null then modelSha256 else ""}}"
+          VERIFY_SHA256="''${VERIFY_SHA256:-1}"
 
           MODEL_HF_REPO="''${MODEL_HF_REPO:-${if modelHfRepo != null then modelHfRepo else ""}}"
 
@@ -106,6 +127,21 @@ let
           if [ ! -f "$MODEL_HOST_DIR/$MODEL_FILENAME" ]; then
             echo "Model artifact is missing: $MODEL_HOST_DIR/$MODEL_FILENAME" >&2
             exit 1
+          fi
+
+          if [ "$VERIFY_SHA256" = "1" ] && [ -n "$MODEL_SHA256" ]; then
+            echo "Verifying artifact checksum (sha256)..." >&2
+            echo "$MODEL_SHA256  $MODEL_HOST_DIR/$MODEL_FILENAME" | sha256sum --check -
+          fi
+
+          if ! ${runtimeBin} image exists "$DOCKER_IMAGE"; then
+            if [ "$BUILD_IMAGE" != "1" ]; then
+              echo "Image $DOCKER_IMAGE not found and BUILD_IMAGE != 1; build it with:" >&2
+              echo "  ${runtimeBin} build --pull -t $DOCKER_IMAGE git+https://github.com/Neroued/ninfer.git#''${NINFER_GIT_REF}:" >&2
+              exit 1
+            fi
+            echo "Building image $DOCKER_IMAGE from git+https://github.com/Neroued/ninfer.git#''${NINFER_GIT_REF} (one-time; pulls the CUDA base images and compiles the engine)..." >&2
+            ${runtimeBin} build --pull --tag "$DOCKER_IMAGE" "git+https://github.com/Neroued/ninfer.git#''${NINFER_GIT_REF}:"
           fi
 
           if [ "$REMOVE_EXISTING_CONTAINER" = "1" ]; then
@@ -128,22 +164,21 @@ let
             --port 8080
             --max-context "$MAX_CONTEXT"
             --kv-capacity "$KV_CAPACITY"
+            --kv-dtype "$KV_DTYPE"
             --max-concurrency "$MAX_CONCURRENCY"
+            --model-id "${modelId}"
           )
 
           if [ -n "$SPEC" ]; then
             args+=(--spec "$SPEC" --draft-tokens "$DRAFT_TOKENS")
-          fi
-
-          if [ "$LM_HEAD_DRAFT" = "1" ]; then
-            args+=(--lm-head-draft)
+            if [ "$LM_HEAD_DRAFT" = "1" ]; then
+              args+=(--lm-head-draft)
+            fi
           fi
 
           if [ "$VISION" = "1" ]; then
             args+=(--vision)
           fi
-
-          args+=(--model-id "${servedModelName}")
 
           # Append any positional arguments beyond the port.
           if [ ''${#EXTRA_ARGS[@]} -gt 0 ]; then
@@ -158,9 +193,11 @@ let
 
           echo "Starting NInfer container:"
           echo "  model:              $MODEL_HOST_DIR/$MODEL_FILENAME"
-          echo "  served model name:  ${servedModelName}"
+          echo "  served model id:    ${modelId}"
           echo "  endpoint:           http://localhost:$HOST_PORT/v1"
           echo "  container image:    $DOCKER_IMAGE"
+          echo "  max context:        $MAX_CONTEXT (kv: $KV_CAPACITY, $KV_DTYPE)"
+          echo "  concurrency:        $MAX_CONCURRENCY (spec: ''${SPEC:-off})"
           echo
 
           set -x
@@ -174,10 +211,16 @@ let
         "ninfer:${servedModelName}" = {
           cmd = "${ninferPkg}/bin/${containerName}";
           proxy = "http://127.0.0.1:${toString port}";
-          name = servedModelName;
-          useModelName = servedModelName;
+          name = "NInfer ${servedModelName}";
+          # The public model id the container accepts (artifact
+          # identity.model_id), not the llama-swap key.
+          useModelName = modelId;
+          # Aliases must be unique across all llama-swap models, so the
+          # bare title-case name is intentionally omitted here — it is
+          # already claimed by the corresponding vLLM variant's aliases.
           aliases = [
-            servedModelName
+            "ninfer"
+            "ninfer:${modelId}"
           ]
           ++ (extraConfig.aliases or [ ]);
           cmdStop = "${runtimeBin} stop ${containerName}";

--- a/hosts/host.thing/myconfig.ai.ninfer/default.nix
+++ b/hosts/host.thing/myconfig.ai.ninfer/default.nix
@@ -1,13 +1,21 @@
 # Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
 # SPDX-License-Identifier: MIT
 
-{
-  config,
-  pkgs,
-  lib,
-  ...
-}:
-
+# NInfer container variants for host.thing. Kept in its own directory
+# (rather than under myconfig.ai.vllm/) since NInfer is a distinct engine
+# from vLLM, even though both currently share the same GPU/port/llama-swap
+# unit on this host.
+#
+# The llama-swap unit's Podman and NVIDIA CDI generator start dependencies
+# are already declared by ../myconfig.ai.vllm/default.nix and
+# ../myconfig.ai.vllm/docker.vllm.cuda.nix, which this host always imports
+# alongside this module (both feature directories target the same NVIDIA
+# RTX 5090 via the same llama-swap instance). They are intentionally *not*
+# repeated here to avoid duplicate Wants=/After= entries on the generated
+# systemd unit. If NInfer is ever used on a host without the vLLM CUDA
+# module, add the equivalent `virtualisation.podman.enable` /
+# `hardware.nvidia-container-toolkit.enable` / llama-swap
+# wants/after wiring here.
 {
   imports = [
     ./docker.ninfer.cuda.nix

--- a/hosts/host.thing/myconfig.ai.ninfer/default.nix
+++ b/hosts/host.thing/myconfig.ai.ninfer/default.nix
@@ -1,0 +1,15 @@
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+{
+  imports = [
+    ./docker.ninfer.cuda.nix
+  ];
+}

--- a/hosts/host.thing/myconfig.ai.ninfer/docker.ninfer.cuda.nix
+++ b/hosts/host.thing/myconfig.ai.ninfer/docker.ninfer.cuda.nix
@@ -1,0 +1,79 @@
+# Copyright 2025 Maximilian Huber <oss@maximilian-huber.de>
+# SPDX-License-Identifier: MIT
+
+# CUDA (NVIDIA RTX 5090) NInfer Podman configurations.
+#
+# Modelled on ../myconfig.ai.vllm/docker.vllm.cuda.nix's
+# `vllmQwen38_27B_NVFP4` variant, but using NInfer
+# (https://github.com/Neroued/ninfer) instead of vLLM, and podman instead of
+# docker as the container runtime.
+
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  common = import ./common.nix { inherit pkgs; };
+  mkNinfer = common.mkNinferDockerized;
+
+  # --- Qwen3.8-27B NVFP4 (NInfer artifact) ---
+  # https://huggingface.co/neroued/Qwen3.8-27B-nvfp4-NInfer
+  ninferQwen38_27B_NVFP4 = mkNinfer {
+    modelHostDir = "/models/neroued-Qwen3.8-27B-nvfp4-NInfer";
+    modelFilename = "qwen3_8_27b_nvfp4.ninfer";
+    modelHfRepo = "neroued/Qwen3.8-27B-nvfp4-NInfer";
+    servedModelName = "qwen3.8-27b";
+    containerName = "ninfer-dockerized-Qwen3.8-27B-NVFP4";
+    port = 22545;
+    extraConfig = {
+      aliases = [
+        "ninfer:qwen3.8-27b-nvfp4"
+      ];
+    };
+  };
+in
+{
+  imports = [
+    {
+      virtualisation.podman.enable = lib.mkDefault true;
+      virtualisation.podman.dockerCompat = lib.mkDefault true;
+      hardware.nvidia-container-toolkit.enable = lib.mkDefault true;
+
+      systemd.services.llama-swap = {
+        wants = [
+          "podman.service"
+          "podman.socket"
+          "nvidia-container-toolkit-cdi-generator.service"
+        ];
+        after = [
+          "podman.service"
+          "podman.socket"
+          "nvidia-container-toolkit-cdi-generator.service"
+        ];
+      };
+    }
+  ];
+  config = {
+    environment.systemPackages = [
+      ninferQwen38_27B_NVFP4.ninferPkg
+    ];
+    services.llama-swap.settings.models = ninferQwen38_27B_NVFP4.modelConfig;
+    home-manager.sharedModules = [
+      {
+        programs.aichat.settings.clients = [
+          {
+            type = "openai-compatible";
+            name = "ninfer";
+            api_base = "http://localhost:22545/v1";
+            models = [
+              { name = "qwen3.8-27b"; }
+            ];
+          }
+        ];
+      }
+    ];
+  };
+}

--- a/hosts/host.thing/myconfig.ai.ninfer/docker.ninfer.cuda.nix
+++ b/hosts/host.thing/myconfig.ai.ninfer/docker.ninfer.cuda.nix
@@ -53,6 +53,12 @@ in
       ninferQwen38_27B_NVFP4.ninferPkg
     ];
     services.llama-swap.settings.models = ninferQwen38_27B_NVFP4.modelConfig;
+    # Declared next to the variant above (rather than in
+    # host.thing/default.nix) so this pull spec isn't silently left
+    # behind and still downloaded if this variant is ever dropped.
+    myconfig.ai.pull_models.models."/home/mhuber/models" = [
+      "neroued/Qwen3.8-27B-nvfp4-NInfer" # ninferQwen38_27B_NVFP4
+    ];
     home-manager.sharedModules = [
       {
         programs.aichat.settings.clients = [

--- a/hosts/host.thing/myconfig.ai.ninfer/docker.ninfer.cuda.nix
+++ b/hosts/host.thing/myconfig.ai.ninfer/docker.ninfer.cuda.nix
@@ -5,8 +5,9 @@
 #
 # Modelled on ../myconfig.ai.vllm/docker.vllm.cuda.nix's
 # `vllmQwen38_27B_NVFP4` variant, but using NInfer
-# (https://github.com/Neroued/ninfer) instead of vLLM, and podman instead of
-# docker as the container runtime.
+# (https://github.com/Neroued/ninfer) instead of vLLM. Serves on the same
+# host port (22545) as the CUDA vLLM variants so llama-swap can swap the
+# engine in and out on the same GPU.
 
 {
   config,
@@ -24,36 +25,27 @@ let
   ninferQwen38_27B_NVFP4 = mkNinfer {
     modelHostDir = "/models/neroued-Qwen3.8-27B-nvfp4-NInfer";
     modelFilename = "qwen3_8_27b_nvfp4.ninfer";
+    # Published SHA-256 (model card artifact table).
+    modelSha256 = "bb3360522a06e136e0367f5703414d26272b7285c8a6ab6194135c17dbd81b32";
     modelHfRepo = "neroued/Qwen3.8-27B-nvfp4-NInfer";
-    servedModelName = "qwen3.8-27b";
+    servedModelName = "Qwen3.8-27B-NVFP4";
+    modelId = "qwen3.8-27b";
     containerName = "ninfer-dockerized-Qwen3.8-27B-NVFP4";
     port = 22545;
-    extraConfig = {
-      aliases = [
-        "ninfer:qwen3.8-27b-nvfp4"
-      ];
-    };
+    # Pinned engine source (master @ 2026-08-19); newer than the
+    # artifact's minimum_revision (5d2c1f55, see artifact-manifest.json).
+    ninferGitRef = "feaf4dd0983fdaeb2ba4c06eec6da350e644fb3a";
+    extraConfig = { };
   };
 in
 {
   imports = [
     {
+      # Self-contained defaults (consistent with the vLLM CUDA sibling);
+      # the llama-swap unit's Podman and NVIDIA CDI start dependencies
+      # are declared in ./default.nix so they are not duplicated.
       virtualisation.podman.enable = lib.mkDefault true;
-      virtualisation.podman.dockerCompat = lib.mkDefault true;
       hardware.nvidia-container-toolkit.enable = lib.mkDefault true;
-
-      systemd.services.llama-swap = {
-        wants = [
-          "podman.service"
-          "podman.socket"
-          "nvidia-container-toolkit-cdi-generator.service"
-        ];
-        after = [
-          "podman.service"
-          "podman.socket"
-          "nvidia-container-toolkit-cdi-generator.service"
-        ];
-      };
     }
   ];
   config = {

--- a/hosts/host.thing/myconfig.ai.vllm/docker.vllm.cuda.nix
+++ b/hosts/host.thing/myconfig.ai.vllm/docker.vllm.cuda.nix
@@ -154,6 +154,14 @@ in
       # // vllmQwen36_27B_int4_AutoRound.modelConfig
       # // vllmQwen36_27B_int4_AutoRound_Lorbus.modelConfig
       // vllmQwen38_27B_NVFP4_Cuda.modelConfig;
+    # Declared next to the variants above (rather than in
+    # host.thing/default.nix) so a pull spec isn't silently left behind
+    # and still downloaded if its variant is ever dropped from this file.
+    myconfig.ai.pull_models.models."/home/mhuber/models" = [
+      "unsloth/Qwen3.8-27B-NVFP4" # vllmQwen38_27B_NVFP4
+      "sakamakismile/Qwen3.8-27B-MTP-NVFP4" # vllmQwen38_27B_MTP_NVFP4
+      "gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090" # vllmQwen38_27B_NVFP4_Cuda
+    ];
     home-manager.sharedModules = [
       {
         programs.aichat.settings.clients = [


### PR DESCRIPTION
Add a NInfer (https://github.com/Neroued/ninfer) counterpart to the vLLM Docker/Podman launch scripts on host thing, modelled on myconfig.ai.vllm/docker.vllm.cuda.nix's Qwen3.8-27B-NVFP4 variant but using podman and NInfer's own CLI/artifact conventions.

- hosts/host.thing/myconfig.ai.ninfer/common.nix: mkNinferDockerized factory (podman run, GPU passthrough via nvidia.com/gpu=all, HF download of the single-file .ninfer artifact, llama-swap modelConfig wiring). No published NInfer image exists upstream, so DOCKER_IMAGE defaults to the locally built `ninfer:local` tag documented in the upstream Dockerfile; this assumption is called out in a comment.
- docker.ninfer.cuda.nix: Qwen3.8-27B-NVFP4 variant serving neroued/Qwen3.8-27B-nvfp4-NInfer on port 22545, registered in environment.systemPackages, services.llama-swap.settings.models, and programs.aichat.settings.clients, matching how the vLLM variant is registered.
- default.nix: imports the cuda variant.
- hosts/host.thing/default.nix: import the new module alongside the existing docker.vllm.rocm.nix import.

Validated by building the package directly against config.environment.systemPackages for test-thing (build-pkg-for-host.sh only inspects home.packages and doesn't apply to this or the vLLM package either), evaluating the test-thing toplevel drvPath, running ./nixfmtall.sh, and shellcheck/shfmt on the generated script.

supported by anthropic/claude-sonnet-5 in pi