### PR TITLE
agent-gvisor: chown the --nix store volume to the session user (U)

### DIFF
--- a/doc/TODOs/validate-agent-gvisor-nix-sessions-on-a-host.md
+++ b/doc/TODOs/validate-agent-gvisor-nix-sessions-on-a-host.md
@@ -21,8 +21,10 @@ that carries this note.
   state dirs and probes `NIX_STORE_DIR` for writability, aborting the
   session with exit 1 otherwise.
 - `modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/rust/src/podman.rs`
-  — the `--mount type=volume,src=<container>-nix,dst=/nix/store` argv and
-  the `NIX_*` env for the session.
+  — the `--mount type=volume,src=<container>-nix,dst=/nix/store,U` argv
+  (the `U` chowns the copy-up to the session user; without it the volume
+  lands root-owned and unwritable under `keep-id` — the failure the first
+  real-host run hit) and the `NIX_*` env for the session.
 - `modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/docs/nix-in-sandbox.md`
   §7 — the host verification checklist V1–V6.
 
@@ -36,6 +38,10 @@ that carries this note.
    In that case switch the host to the documented writable-rootfs fallback
    (§2 "Drop `--read-only`") or drop `--nix` on that host — do not paper
    over the preflight.
+   (History: the first real-host run of V1 failed because the volume mount
+   lacked the `U` option — the copy-up landed root-owned and unwritable
+   under `keep-id`. Fixed since; only a `U`-chown failure under a specific
+   Podman/runsc combination still justifies the fallback.)
 3. Record the outcome (host, podman/runsc versions, what worked) in
    `docs/nix-in-sandbox.md` §7, then enable `nix.enable` for that host in
    `hosts/host.<name>/ai.<name>.nix`.

--- a/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/README.md
+++ b/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/README.md
@@ -297,8 +297,9 @@ agent-gvisor doctor       # verify runtime, image and sandbox startup
 With `myconfig.ai.gvisor-agent-sandbox.nix.enable = true` the image bakes
 `config.nix.package` and every session defaults to `--nix`: a per-session
 Podman volume mounted at `/nix/store`, seeded by copy-up with the image's
-own store paths (so the `/bin` toolchain keeps working) and writable, so
-nix substitutes what a build needs from the configured binary caches —
+own store paths (so the `/bin` toolchain keeps working) and chowned to the
+session user (Podman's `U` mount option) so nix can substitute what a
+build needs from the configured binary caches —
 host-mirrored `substituters` and `trusted-public-keys`, passed in as the
 container env `NIX_CONFIG` via `AGENT_GVISOR_NIX_CONFIG`. Nix runs
 daemon-less (`NIX_REMOTE=local`, state under `/home/agent/.local/state/nix`)

--- a/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/docs/nix-in-sandbox.md
+++ b/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/docs/nix-in-sandbox.md
@@ -20,7 +20,7 @@ four ways:
    `<container>-nix`, i.e. `agent-<repo-id>-<name>-nix`):
 
    ```
-   --mount type=volume,src=<container>-nix,dst=/nix/store
+   --mount type=volume,src=<container>-nix,dst=/nix/store,U
    ```
 
    The image *contains* a real `/nix/store` (the closure of the baked
@@ -31,6 +31,22 @@ four ways:
    itself — baked into the image when `nix.enable` is set) keeps working
    *before the first in-container process runs*, and the store becomes
    writable, so nix can substitute new paths into it.
+
+   The `U` (chown) mount option is what makes the last sentence true
+   under `--userns=keep-id`. Without it, Podman's post-copy-up
+   `fixVolumePermissions` chmods the volume root to the image
+   directory's mode — and nixpkgs' `dockerTools` builds `/nix/store`
+   read-only (0555) in every image layer, precisely so the store is
+   world-readable. 0555 is unwritable even for its owner, so the store
+   can never accept a write, the init preflight (§1.2) aborts the
+   session with the §7 V1 error, and the failure is deterministic — no
+   host quirk. With `U`, Podman instead recursively chowns the seeded
+   store to the container's process user — under keep-id, the session's
+   own host uid — and skips the mode copy, so the root keeps the 0755
+   the volume driver created it with. The chown re-runs on every `run
+   --replace` recreation (a walk that skips already-owned entries, cheap
+   next to the copy-up), which also heals a volume seeded by an older
+   CLI without the option.
 
    The volume is the only writable Nix store state; it lives in the
    rootless Podman volume store (`~/.local/share/containers/storage/`),
@@ -124,6 +140,15 @@ four ways:
   which is masked). The farm would have to be created host-side before
   container start, which requires shipping the image's closure list to
   the CLI — complexity with no advantage over copy-up.
+- **Rely on the copy-up without the `U` mount option.** Rejected after it
+  failed on the first real host (§7 V1): Podman's post-copy-up
+  `fixVolumePermissions` chmods the volume root to the image directory's
+  mode when `U` is absent, and nixpkgs' `dockerTools` marks `/nix/store`
+  read-only (0555) in every image — so the store could not accept a
+  single write and the init preflight failed closed. The `U` option is
+  Podman's own mechanism for exactly this case (chown the volume to the
+  container user, keep the driver's mode), so it is part of the design
+  now, not a fallback.
 - **Drop `--read-only`** (writable container rootfs): everything
   "just works" mechanically — the image store stays visible and the
   writable layer accepts new paths. Rejected as the default because it
@@ -241,13 +266,15 @@ module defaults to off for exactly that reason.
    `agent-gvisor start t1 --nix --detach`, then inside
    (`agent-gvisor shell t1`) check that `ls /nix/store` shows the image
    closure AND that the store dir is writable by the agent
-   (`touch /nix/store/.probe`). If the copy-up lands as container-root
-   (uid unmapped under `keep-id`) and the write fails: this host needs
-   the read-only-rootfs fallback — image-level writable rootfs —
-   and the volume approach must be revisited upstream.
-   The failure is *loud*: `start --nix` aborts with
-   `agent-gvisor-init: error: /nix/store is not writable in this sandbox`
-   (§1.2), so V1 cannot pass by accident.
+   (`touch /nix/store/.probe`). The volume mount carries the `U` option
+   (§1.1), so the copy-up content is chowned to the session user at
+   create time and the write must succeed on any conforming
+   Podman; if it still fails on a host, the `U` chown itself misbehaves
+   under that runsc/Podman combination — that host needs the read-only-
+   rootfs fallback (image-level writable rootfs) and the volume approach
+   must be revisited upstream. The failure is *loud*: `start --nix` aborts
+   with `agent-gvisor-init: error: /nix/store is not writable in this
+   sandbox` (§1.2), so V1 cannot pass by accident.
 2. **Daemon-less nix:** `nix store info` in the session must print the
    store without daemon errors; `nix build nixpkgs#hello` must
    substitute, build and run.

--- a/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/docs/spec.md
+++ b/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/docs/spec.md
@@ -485,7 +485,9 @@ podman <global args> run --replace (--detach | --interactive --tty)
   --workdir <repo>
   --mount type=bind,src=<worktree>,dst=<repo>,rw
   --mount type=bind,src=<home>,dst=/home/agent,rw
-  [--mount type=volume,src=<container>-nix,dst=/nix/store]  # only when nix=true
+  [--mount type=volume,src=<container>-nix,dst=/nix/store,U]  # only when nix=true;
+                                                          # U chowns the copy-up to the
+                                                          # session user (§7 V1)
   --env HOME=/home/agent
   --env XDG_CONFIG_HOME=/home/agent/.config
   --env XDG_CACHE_HOME=/home/agent/.cache

--- a/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/nix/agent-gvisor-init.sh
+++ b/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/nix/agent-gvisor-init.sh
@@ -122,10 +122,22 @@ if [ -n "${AGENT_GVISOR_NIX-}" ]; then
     # is the store nix would actually use; the CLI never sets it, so this
     # is /nix/store in every real session.
     store=${NIX_STORE_DIR:-/nix/store}
-    dir_is_writable "$store" ||
+    if ! dir_is_writable "$store"; then
+        # Diagnose before dying: an EMPTY store means the copy-up never
+        # seeded the volume; a read-only mode bit on the root is the
+        # chmod-to-image-mode failure the `U` mount option prevents
+        # (§1.1); ownership by someone else (an unmapped uid under
+        # keep-id) is the remaining case. `id`/`stat`/`ls` are in the
+        # image (shadow, coreutils); their absence degrades to a bare
+        # die.
+        store_stat=$(stat -c 'owner %u:%g mode %a' "$store" 2>/dev/null || true)
+        store_count=$(ls -A "$store" 2>/dev/null | wc -l)
+        log "store diagnosis: $store: ${store_stat:-stat unavailable}, " \
+            "${store_count} entries; this process is $(id -u 2>/dev/null):$(id -g 2>/dev/null)"
         die "$store is not writable in this sandbox;" \
             "the --nix store volume did not come up (copy-up/ownership);" \
             "see docs/nix-in-sandbox.md §7 V1"
+    fi
 fi
 
 # The payload replaces this shell, so it keeps PID 1, the TTY and all signals.

--- a/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/rust/src/podman.rs
+++ b/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/rust/src/podman.rs
@@ -141,10 +141,24 @@ pub fn build_run_args(
     // (so the /bin toolchain — all symlinks into /nix/store — keeps
     // working) and writable by the agent. The volume outlives container
     // recreation (`run --replace`) and is removed by `destroy`.
+    //
+    // The `U` (chown) option makes the store usable: Podman's post-copy-up
+    // `fixVolumePermissions` otherwise chmods the volume root to the image
+    // directory's mode — and dockerTools marks /nix/store read-only (0555)
+    // in every image, unwritable even for its owner, so the store could
+    // not accept a single write and the init preflight aborted the session
+    // (docs/nix-in-sandbox.md §7 V1 — deterministic, not host-specific).
+    // With `U`, Podman instead recursively chowns the seeded volume to the
+    // container's process user — under `--userns=keep-id` the session's
+    // own host uid — and skips the mode copy, keeping the 0755 the volume
+    // driver created the root with. The chown re-runs on every `run
+    // --replace` recreation (a walk that skips already-owned entries,
+    // cheap next to the copy-up) and thereby heals volumes seeded by an
+    // older CLI without the option.
     if nix_on {
         cmd.extend([
             "--mount".to_string(),
-            format!("type=volume,src={},dst=/nix/store", nix_volume_name(meta)),
+            format!("type=volume,src={},dst=/nix/store,U", nix_volume_name(meta)),
         ]);
     }
     cmd.extend([

--- a/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/rust/tests/podman_argv.rs
+++ b/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/rust/tests/podman_argv.rs
@@ -83,7 +83,7 @@ fn build_run_args_nix() {
         &args[pos + 1..pos + 3],
         &[
             "--mount".to_string(),
-            format!("type=volume,src={},dst=/nix/store", agent_gvisor::podman::nix_volume_name(&meta)),
+            format!("type=volume,src={},dst=/nix/store,U", agent_gvisor::podman::nix_volume_name(&meta)),
         ]
     );
     // The Nix env block directly follows the fixed envs (no loopback forward
@@ -138,7 +138,7 @@ fn start_nix_records_volume_and_destroy_removes_it() {
         .join("s1");
 
     let run = s.recorded_starting_with("podman", "run")[0].clone();
-    assert!(run.contains(&format!("type=volume,src={container}-nix,dst=/nix/store")));
+    assert!(run.contains(&format!("type=volume,src={container}-nix,dst=/nix/store,U")));
     assert!(run.contains(&"NIX_REMOTE=local".to_string()));
     assert!(run.contains(&"AGENT_GVISOR_NIX=1".to_string()));
     assert!(run.contains(&"/bin/agent-gvisor-init".to_string()));

--- a/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/tests/agent-gvisor-cli-harness.sh
+++ b/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/tests/agent-gvisor-cli-harness.sh
@@ -162,7 +162,7 @@ done
 # A `--nix` session: the store volume mount in the argv, and its cleanup.
 echo "== nix sessions =="
 expect_ok "start a --nix session" start n1 --repo "$REPO" --nix --detach
-if argv_has 'type=volume,src=.*-n1-nix,dst=/nix/store'; then
+if argv_has 'type=volume,src=.*-n1-nix,dst=/nix/store,U'; then
     printf 'ok   podman argv mounts the nix store volume\n'
     passed=$((passed + 1))
 else

--- a/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/tests/agent-gvisor-init-harness.sh
+++ b/modules/myconfig.ai/myconfig.ai.gvisor-agent-sandbox/tests/agent-gvisor-init-harness.sh
@@ -114,12 +114,15 @@ else
     fail "NIX_STATE_DIR created"
 fi
 
-# 2. Store not writable (the copy-up/ownership failure mode, §7 V1): refuse.
+# 2. Store not writable (the copy-up/ownership failure mode, §7 V1): refuse,
+#    with a diagnosis line that names owner/mode/entry count so a host run
+#    pinpoint which part of V1 broke.
 root="$(scenario ro-store)"
 chmod a-w "$root/store"
 run_init "$root"
 expect_status "unwritable store aborts the session" 1
 expect_output "unwritable store is reported" "is not writable in this sandbox"
+expect_output "store failure is diagnosed" "store diagnosis"
 expect_payload "payload does not run on an unusable store" not-ran
 
 # 3. Store writable, but NIX_STATE_DIR cannot be created (read-only parent,


### PR DESCRIPTION
The first real-host run of a `--nix` session failed the §7 V1 preflight: `/nix/store is not writable in this sandbox`. Root cause, traced through Podman's volume handling (v5.6, libpod): after the copy-up seeds the named volume with the image's store closure, `fixVolumePermissions` chmods the volume root to the image directory's mode — and nixpkgs' dockerTools marks `/nix/store` read-only (0555) in every image layer. 0555 is unwritable even for its owner, so the store could never accept a write: the failure is deterministic on every host, not a keep-id/runsc quirk.

Fix: mount the volume with Podman's own `U` (chown) option — `type=volume,src=<container>-nix,dst=/nix/store,U`. With `U`, Podman recursively chowns the seeded store to the container's process user (the session's own host uid under keep-id) and skips the mode copy, keeping the 0755 the volume driver created the root with. The chown re-runs on every `run --replace` recreation, healing volumes seeded by an older CLI.

Also teach the init preflight to diagnose before dying (owner, mode, entry count of the store, plus the current uid/gid), so a future V1 failure pinpoints which part broke (no copy-up / bad mode / unmapped owner) in the container logs.

- rust/src/podman.rs: the mount gains `U`
- rust/tests + tests/agent-gvisor-cli-harness.sh: assert the `U`
- nix/agent-gvisor-init.sh + its harness: the diagnosis line
- docs (nix-in-sandbox.md §1/§2/§7, spec.md §10, README) and the §7 validation TODO note: record the mechanism and the history

supported by trustedtokens/zai-org/GLM-5.3 in pi